### PR TITLE
Decouple more with goal of having tests independent of YAML config

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,43 @@ import json
 import pytest
 from graphene_django.utils.testing import graphql_query
 
+from nodes.tests.factories import (
+    ActionNodeFactory, ContextFactory, CustomScenarioFactory, InstanceFactory, ScenarioFactory
+)
+
+
+@pytest.fixture
+def context():
+    return ContextFactory()
+
+
+@pytest.fixture
+def action_node(context):
+    return ActionNodeFactory(context=context)
+
+
+@pytest.fixture(autouse=True)  # autouse=True since InstanceMiddleware requires a default scenario
+def default_scenario(context, action_node):
+    return ScenarioFactory(context=context, default=True, all_actions_enabled=True, nodes=[action_node])
+
+
+@pytest.fixture
+def custom_scenario(context, action_node, default_scenario):
+    return CustomScenarioFactory(
+        context=context,
+        id='custom',
+        name='Custom',
+        base_scenario=default_scenario,
+        nodes=[action_node],
+    )
+
+
+@pytest.fixture(autouse=True)
+def instance(context):
+    from pages import global_instance
+    global_instance.instance = InstanceFactory(context=context)
+    return global_instance.instance
+
 
 @pytest.fixture
 def graphql_client_query(client):

--- a/nodes/actions/action.py
+++ b/nodes/actions/action.py
@@ -67,3 +67,8 @@ class ActionNode(Node):
     def print_impact(self, target_node: Node):
         df = self.compute_impact(target_node)
         self.print_pint_df(df)
+
+    def on_scenario_created(self, scenario):
+        super().on_scenario_created(scenario)
+        param = self.get_param('enabled')
+        scenario.params[param.id] = scenario.all_actions_enabled

--- a/nodes/context.py
+++ b/nodes/context.py
@@ -122,8 +122,9 @@ class Context:
         return root_nodes[0].compute()
 
     def activate_scenario(self, scenario: Scenario):
+        assert scenario.context == self
         # Set the new parameters
-        scenario.activate(self)
+        scenario.activate()
         self.active_scenario = scenario
 
     def get_default_scenario(self) -> Scenario:

--- a/nodes/instance.py
+++ b/nodes/instance.py
@@ -154,8 +154,7 @@ class InstanceLoader:
                     fields['name'] = description
                 param = type(param_obj)(**fields)
                 for scenario_id, value in scenario_values.items():
-                    scenario = self.scenario_node_params.setdefault(scenario_id, {})
-                    scenario_params = scenario.setdefault(node.id, {})
+                    scenario_params = node.scenario_params.setdefault(scenario_id, {})
                     scenario_params[param.id] = param.clean(value)
 
                 node.allowed_params.append(type(param_obj)(**fields))
@@ -234,26 +233,15 @@ class InstanceLoader:
         default_scenario = None
 
         for sc in self.config['scenarios']:
-            all_actions_enabled = sc.pop('all_actions_enabled', False)
             name = self.make_trans_string(sc, 'name', pop=True)
-            params = sc.pop('params', [])
-            scenario = Scenario(**sc, name=name)
-
-            for node in self.context.nodes.values():
-                if not isinstance(node, ActionNode):
-                    continue
-                param = node.get_param('enabled')
-                scenario.params[param.id] = all_actions_enabled
-
-            for pc in params:
+            params_config = sc.pop('params', [])
+            params = {}
+            for pc in params_config:
                 param = self.context.get_param(pc['id'])
-                scenario.params[param.id] = param.clean(pc['value'])
+                params[param.id] = param.clean(pc['value'])
+                # scenario.params[param.id] = param.clean(pc['value'])
 
-            for node_id, node_params in self.scenario_node_params.get(scenario.id, {}).items():
-                node = self.context.get_node(node_id)
-                for param_id, val in node_params.items():
-                    param = node.get_param(param_id, local=True)
-                    scenario.params[param.id] = val
+            scenario = Scenario(**sc, name=name, context=self.context, params=params, nodes=self.context.nodes.values())
 
             if scenario.default:
                 assert default_scenario is None
@@ -262,7 +250,11 @@ class InstanceLoader:
 
         self.context.add_scenario(
             CustomScenario(
-                id='custom', name='Custom', base_scenario=default_scenario
+                id='custom',
+                name='Custom',
+                context=self.context,
+                base_scenario=default_scenario,
+                nodes=self.context.nodes.values(),
             )
         )
 
@@ -334,7 +326,6 @@ class InstanceLoader:
         self.context.target_year = self.config['target_year']
 
         self.load_datasets(self.config.get('datasets', []))
-        self.scenario_node_params = {}
         # Store input and output node configs for each created node, to be used in setup_edges().
         self._input_nodes = {}
         self._output_nodes = {}

--- a/nodes/node.py
+++ b/nodes/node.py
@@ -54,6 +54,8 @@ class Node:
 
     # Parameters with their values
     params: Dict[str, Parameter]
+    # Maps a scenario to scenario-specific parameters and their values
+    scenario_params: Dict[str, Dict[str, Parameter]]
 
     # All allowed parameters for this class or object
     allowed_params: Iterable[Parameter]
@@ -81,6 +83,7 @@ class Node:
         self.baseline_values = None
         self.params = {}
         self.content = None
+        self.scenario_params = {}
 
         # Call the subclass post-init method if it is defined
         if hasattr(self, '__post_init__'):
@@ -283,6 +286,13 @@ class Node:
                     result.append(current)
                 open += current.input_nodes
         return result
+
+    def on_scenario_created(self, scenario):
+        """Called when a scenario is created with this node among the nodes to be notified."""
+        scenario_params = self.scenario_params.get(scenario.id, {})
+        for param_id, val in scenario_params.items():
+            param = self.get_param(param_id, local=True)
+            scenario.params[param.id] = val
 
     def __str__(self):
         return '%s [%s]' % (self.id, str(type(self)))

--- a/nodes/tests/factories.py
+++ b/nodes/tests/factories.py
@@ -1,0 +1,57 @@
+from factory import Factory, PostGeneration, Sequence, SubFactory
+
+from common.i18n import TranslatedString
+from nodes.actions import ActionNode
+from nodes.context import Context
+from nodes.instance import Instance
+from nodes.node import Node
+from nodes.scenario import CustomScenario, Scenario
+
+
+class ContextFactory(Factory):
+    class Meta:
+        model = Context
+
+
+class InstanceFactory(Factory):
+    class Meta:
+        model = Instance
+
+    id = 'test'
+    name = 'test'
+    context = SubFactory(ContextFactory)
+
+
+class NodeFactory(Factory):
+    class Meta:
+        model = Node
+
+    context = SubFactory(ContextFactory)
+    id = Sequence(lambda i: f'node{i}')
+
+    add_to_context = PostGeneration(lambda obj, create, extracted, **kwargs: obj.context.add_node(obj))
+
+
+class ActionNodeFactory(NodeFactory):
+    class Meta:
+        model = ActionNode
+
+
+class ScenarioFactory(Factory):
+    class Meta:
+        model = Scenario
+
+    context = SubFactory(ContextFactory)
+    id = Sequence(lambda i: f'scenario{i}')
+    name = TranslatedString('scenario')
+    default = False
+    params = None
+
+    add_to_context = PostGeneration(lambda obj, create, extracted, **kwargs: obj.context.add_scenario(obj))
+
+
+class CustomScenarioFactory(ScenarioFactory):
+    class Meta:
+        model = CustomScenario
+
+    base_scenario = SubFactory(ScenarioFactory)

--- a/pages/global_instance.py
+++ b/pages/global_instance.py
@@ -1,14 +1,12 @@
 import os
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 
 from nodes.instance import InstanceLoader
 
+instance = None
 
-if settings.INSTANCE_LOADER_CONFIG is None:
-    raise ImproperlyConfigured('Global instance requires the INSTANCE_LOADER_CONFIG setting')
-
-loader = InstanceLoader.from_yaml(os.path.join(settings.BASE_DIR, settings.INSTANCE_LOADER_CONFIG))
-instance = loader.instance
-instance.context.print_graph()
-instance.context.generate_baseline_values()
+if settings.INSTANCE_LOADER_CONFIG is not None:
+    loader = InstanceLoader.from_yaml(os.path.join(settings.BASE_DIR, settings.INSTANCE_LOADER_CONFIG))
+    instance = loader.instance
+    instance.context.print_graph()
+    instance.context.generate_baseline_values()

--- a/paths/tests/test_schema.py
+++ b/paths/tests/test_schema.py
@@ -1,13 +1,16 @@
 import pytest
 
+from nodes.tests.factories import ActionNodeFactory, ScenarioFactory
+
 pytestmark = pytest.mark.django_db
 
 
-def test_action_enabled(graphql_client_query_data):
+def test_action_enabled(graphql_client_query_data, context, action_node):
+    param_id = f'{action_node.id}.enabled'
     data = graphql_client_query_data(
         '''
-        query {
-          parameter(id: "action.enabled") {
+        query($param: ID!) {
+          parameter(id: $param) {
             __typename
             id
             ... on BoolParameterType {
@@ -16,22 +19,24 @@ def test_action_enabled(graphql_client_query_data):
           }
         }
         ''',
+        variables={'param': param_id}
     )
     expected = {
         'parameter': {
             '__typename': 'BoolParameterType',
-            'id': 'action.enabled',
+            'id': param_id,
             'value': True,
         }
     }
     assert data == expected
 
 
-def test_set_parameter_disable_action(graphql_client_query_data):
+def test_set_parameter_disable_action(graphql_client_query_data, context, action_node, custom_scenario):
+    param_id = f'{action_node.id}.enabled'
     data = graphql_client_query_data(
         '''
-        mutation {
-          setParameter(id: "action.enabled", boolValue: false) {
+        mutation($param: ID!) {
+          setParameter(id: $param, boolValue: false) {
             ok
             parameter {
               id
@@ -42,12 +47,13 @@ def test_set_parameter_disable_action(graphql_client_query_data):
           }
         }
         ''',
+        variables={'param': param_id}
     )
     expected = {
         'setParameter': {
             'ok': True,
             'parameter': {
-                'id': 'action.enabled',
+                'id': param_id,
                 'value': False,
             }
         }


### PR DESCRIPTION
This is WIP, but I think it's important to get some feedback, since I'm not entirely sure if my changes have some unpleasant side-effects. `InstanceLoader`, `Instance`, `Context`, `Node`, `Scenario`, etc. are extremely tightly coupled so that it's almost impossible to test anything more or less individually. Also regardless of the tests I think it would be nice to make things easier to maintain and less likely to break.