### PR TITLE
Update Zürich labels and sector colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Install the required Python packages:
 ```shell
 pip install -r requirements.txt
 ```
+
+> _Note for macOS users: If you run into issues installing python-snappy, install it separately first_
+>
+> ```
+> brew install snappy
+> CPPFLAGS="-I/opt/homebrew/include -L/opt/homebrew/lib" pip install python-snappy
+> ```
+
 Create a file called `local_settings.py` in your repo root with the following contents:
 
 ```python
@@ -27,8 +35,8 @@ DEBUG = True
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': f'{BASE_DIR}/db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'paths',
         'ATOMIC_REQUESTS': True,
     }
 }
@@ -41,6 +49,7 @@ python manage.py migrate
 ```
 
 Create a superuser:
+
 > You might need the following translations during the createsuperuser operation: käyttäjätunnus = username, sähköpostiosoite = e-mail
 
 ```shell

--- a/configs/zuerich.yaml
+++ b/configs/zuerich.yaml
@@ -49,15 +49,15 @@ action_groups:
 - id: buildings
   name: Gebäude
   name_en: Buildings and Heat Supply
-  color: '#002F96'
+  color: '#989898'
 - id: mobility
   name: Mobilität
   name_en: Transportation
-  color: '#E22D53'
+  color: '#0505A0'
 - id: waste
   name: Entsorgung
   name_en: Waste
-  color: '#F18830'
+  color: '#007C78'
 - id: other
   name: Andere
   name_en: Other
@@ -87,7 +87,7 @@ dimensions:
   - id: negative
     label: Negative Emissionen
     label_en: Negative emissions
-    color: '#F7A5AF'
+    color: '#8ECF69'
     #id_match: ^negative_emissions$
     order: -1
   categories:
@@ -112,7 +112,7 @@ dimensions:
   - id: negative_emissions
     label_de: Negative Emissionen
     label_en: Negative emissions
-    color: '#F7A5AF'
+    color: '#8ECF69'
     order: -1
     group: negative
 
@@ -737,7 +737,7 @@ emission_sectors:
   name_de: Negative Emissionen
   name_en: Negative emissions
   part_of: net_emissions
-  color: '#F7A5AF'
+  color: '#8ECF69'
   order: -1
 
 # - id: direct_emissions
@@ -780,7 +780,7 @@ emission_sectors:
   short_name_en: Food consumption
   category: food_consumption
   part_of: net_emissions
-  color: '#BCE59E'
+  color: '#002914'
   input_dataset_processors: [LinearInterpolation]
 
 - id: textile_consumption_emissions
@@ -790,7 +790,7 @@ emission_sectors:
   short_name_en: Textile consumption
   category: textile_consumption
   part_of: net_emissions
-  color: '#FBCB97'
+  color: '#EB5E00'
   input_dataset_processors: [LinearInterpolation]
 
 - id: other_consumption_emissions
@@ -800,7 +800,7 @@ emission_sectors:
   short_name_en: Other consumption
   category: other_consumption
   part_of: net_emissions
-  color: '#2AC7C7'
+  color: '#A174DE'
   input_dataset_processors: [LinearInterpolation]
 
 nodes:
@@ -1467,7 +1467,7 @@ nodes:
   name_de: Treibhausgasemissionen Gebäude
   short_name_de: Gebäude
   short_name_en: Buildings
-  color: '#002F96'
+  color: '#989898'
   unit: kt/a
   quantity: emissions
   type: simple.SectorEmissions
@@ -1487,7 +1487,7 @@ nodes:
   quantity: emissions
   unit: kt/a
   type: simple.SectorEmissions
-  color: '#E22D53'
+  color: '#0505A0'
   input_dimensions: [emission_scope]
   output_dimensions: [emission_scope]
   output_nodes: [net_emissions]
@@ -2155,7 +2155,7 @@ nodes:
   output_dimensions: [emission_scope]
   output_nodes: [net_emissions]
   type: simple.SectorEmissions
-  color: '#F18830'
+  color: '#007C78'
 
 - id: afolu_emissions
   name_de: Treibhausgasemissionen Land- und Forstwirtschaft
@@ -2177,6 +2177,7 @@ nodes:
     - id: emission_sectors
       flatten: true
   input_dataset_processors: [LinearInterpolation]
+  color: '#F1D900'
 
 - id: building_fgas_emissions
   name_en: F-gas emissions from buildings
@@ -4025,14 +4026,6 @@ pages:
   path: /
   type: emission
   outcome_node: net_emissions
-  lead_title_en: Development version
-  lead_title_de: Entwicklungsversion
-  lead_paragraph_en: This is a test version of the City of Zürich's interactive scenario
-    modeling platform for the Net Zero goal. All information on this website is to
-    be considered incomplete and experimental.
-  lead_paragraph_de: Dies ist eine Testversion der interaktiven Szenariomodellierungsplattform
-    zum Klimaschutzziel Netto-Null 2040. Alle Informationen auf dieser Website sind
-    als unvollständig und provisorisch zu verstehen.
 
 - id: 2000watt
   name_en: 2000-Watt

--- a/configs/zuerich.yaml
+++ b/configs/zuerich.yaml
@@ -7,8 +7,8 @@ dataset_repo:
   commit: 959c8ae71be5e47bdb839535db99e8129400e444
   dvc_remote: kausal-s3-private
   default_path: zuerich
-name_en: Net Zero 2040
-name_de: Netto-Null 2040
+name_en: Net Zero Cockpit
+name_de: Netto-Null Cockpit
 owner_en: City of Zürich
 owner_de: Stadt Zürich
 theme_identifier: zurich
@@ -47,7 +47,7 @@ terms:
 action_groups:
 # Handlungsfeld
 - id: buildings
-  name: Gebäude und Wärmeversorgung
+  name: Gebäude
   name_en: Buildings and Heat Supply
   color: '#002F96'
 - id: mobility
@@ -4020,8 +4020,8 @@ actions:
 
 pages:
 - id: home
-  name_en: Net Zero 2040
-  name_de: Netto-Null 2040
+  name_en: Emissions
+  name_de: Treibhausgasemissionen
   path: /
   type: emission
   outcome_node: net_emissions


### PR DESCRIPTION
### Updated colours in context

<img width="992" alt="Screenshot 2023-10-30 at 15 15 50" src="https://github.com/kausaltech/kausal-paths/assets/15343658/7718f7dd-eb1a-421c-9922-a68d94146bc4">
<img width="978" alt="Screenshot 2023-10-30 at 15 15 40" src="https://github.com/kausaltech/kausal-paths/assets/15343658/30f533a5-b8b8-4f96-ba57-3101e561c020">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205803372041843