### PR TITLE
Admin UI button to save dataset to DVC

### DIFF
--- a/datasets/management/commands/store_dvc_dataset.py
+++ b/datasets/management/commands/store_dvc_dataset.py
@@ -1,16 +1,14 @@
-from dvc_pandas import Dataset as DVCDataset, Repository
-from rich.table import Table
-from rich.console import Console
+from django.core.management.base import BaseCommand
 
-from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from dvc_pandas import Dataset as DVCDataset, Repository
+from rich.console import Console
+from rich.table import Table
+
 from common.i18n import get_translated_string_from_modeltrans
-from datasets.models import Dataset, DatasetDimension, Dimension, DatasetMetric
-from common import polars as ppl
+from datasets.models import Dataset
 from nodes.datasets import JSONDataset
 from nodes.models import InstanceConfig
 from nodes.node import Context
-from nodes.constants import FORECAST_COLUMN, YEAR_COLUMN
 
 
 class Command(BaseCommand):

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -1,27 +1,28 @@
 from __future__ import annotations
+
 from datetime import date
-import logging
 
-import pandas as pd
-import polars as pl
-import pint_pandas
-from django.db.models import QuerySet
-from django.db import models, transaction
-from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import ArrayField
-
-from modeltrans.fields import TranslationField
-from modeltrans.manager import MultilingualManager, MultilingualQuerySet
+from django.db import models, transaction
+from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel, ParentalKey
+from modeltrans.fields import TranslationField
 from wagtail.admin.panels import FieldPanel, InlinePanel
 
-from paths.utils import IdentifierField, IdentifierValidator, OrderedModel, UUIDIdentifierField, UnitField, UserModifiableModel
-from nodes.models import InstanceConfig
+import pandas as pd
+import pint_pandas
+import polars as pl
+
+from common.i18n import get_modeltrans_attrs_from_str
 from nodes.constants import YEAR_COLUMN
 from nodes.datasets import JSONDataset
 from nodes.dimensions import Dimension as NodeDimension
-from common.i18n import I18nString, TranslatedString, get_modeltrans_attrs_from_str
-from common import polars as ppl
+from nodes.models import InstanceConfig
+from paths.utils import (
+    IdentifierField, OrderedModel, UnitField, UserModifiableModel,
+    UUIDIdentifierField
+)
 
 
 class DatasetQuerySet(QuerySet['Dataset']):

--- a/paths/settings.py
+++ b/paths/settings.py
@@ -56,7 +56,9 @@ env = environ.FileAwareEnv(
     MEDIA_FILES_S3_ACCESS_KEY_ID=(str, ''),
     MEDIA_FILES_S3_SECRET_ACCESS_KEY=(str, ''),
     MEDIA_FILES_S3_CUSTOM_DOMAIN=(str, ''),
-    WATCH_DEFAULT_API_BASE_URL=(str, 'https://api.watch.kausal.tech')
+    WATCH_DEFAULT_API_BASE_URL=(str, 'https://api.watch.kausal.tech'),
+    GITHUB_APP_ID=(str, ''),
+    GITHUB_APP_PRIVATE_KEY=(str, '')
 )
 
 BASE_DIR = root()
@@ -429,6 +431,10 @@ BASE_URL = env('ADMIN_BASE_URL')
 WAGTAILADMIN_BASE_URL = BASE_URL
 
 WATCH_DEFAULT_API_BASE_URL = env('WATCH_DEFAULT_API_BASE_URL')
+
+# Information needed to authentiacte as a GitHub App
+GITHUB_APP_ID = env('GITHUB_APP_ID')
+GITHUB_APP_PRIVATE_KEY = env('GITHUB_APP_PRIVATE_KEY')
 
 INSTANCE_LOADER_CONFIG = 'configs/tampere.yaml'
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1206977717484257/1207044081814361/f

Add button to the admin UI for saving dataset to DVC to make the current dataset management workflow easier (currently this has to be done manually with `manage.py` commands).

Related PR in kausal-extensions: https://github.com/kausaltech/kausal-extensions/pull/21


### How to test
- Change the `dataset_repo` url in a kausal-paths config file to point to the test repo, e.g.:
```
diff --git a/configs/zuerich.yaml b/configs/zuerich.yaml
index 2fe47cd..f5761ee 100644
--- a/configs/zuerich.yaml
+++ b/configs/zuerich.yaml
@@ -3,7 +3,7 @@ default_language: de-CH
 supported_languages: [en]
 site_url: https://zuerich.paths-test.kausal.tech
 dataset_repo:
-  url: https://github.com/kausaltech/dvctest.git
+  url: https://github.com/kausaldev/dvc-datasets-dev.git
   commit: 1f5c51a92580e80e439330473ffc602f61c4d1d3
   dvc_remote: kausal-s3-private
   default_path: zuerich
   ```

- Add new environment variables to your kausal-paths `.env` file:
```
GITHUB_APP_ID=882893
GITHUB_APP_PRIVATE_KEY_FILE=<ask for the file from me personally, enter local path to the file here>
```
- Use kausal-paths Admin UI to edit a dataset, then press the "Save to DVC" button