### PR TITLE
Fix signal for InstanceSiteContent creation

### DIFF
--- a/nodes/apps.py
+++ b/nodes/apps.py
@@ -6,5 +6,5 @@ class NodesConfig(AppConfig):
 
     def ready(self) -> None:
         from nodes.units import add_unit_translations
-
+        import nodes.signals
         add_unit_translations()

--- a/nodes/signals.py
+++ b/nodes/signals.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save
 
 from pages.models import InstanceSiteContent
 
-@receiver(post_save, sender=InstanceConfig())
+@receiver(post_save, sender=InstanceConfig)
 def create_instance_site_content(sender, instance, created, **kwargs):
     if created:
         InstanceSiteContent.objects.create(instance=instance)


### PR DESCRIPTION
Fix to nodes/signals so that InstanceSiteContent is created upon InstanceConfig creation 


Tested:
Creating a InstanceConfig in shell and checking that the site_content was there.