### PR TITLE
Update README.md to include note about DJANGO_SETTINGS_MODULE

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ DATABASES = {
 }
 ```
 
+Set `DJANGO_SETTINGS_MODULE` (Unix Bash shell):
+```shell
+export DJANGO_SETTINGS_MODULE=paths.settings
+```
+
 Run migrations:
 
 ```shell


### PR DESCRIPTION
Previously, migrations command, described in `README.md` file:
```
python manage.py migrate
```
failed with `RuntimeError`:
```
[app]   |   File "/paths/authentication.py", line 5, in <module>
[app]   |     from oauth2_provider.views.mixins import OAuthLibMixin
[app]   |   File "/venv/lib/python3.12/site-packages/oauth2_provider/views/__init__.py", line 2, in <module>
[app]   |     from .base import AuthorizationView, TokenView, RevokeTokenView  # isort:skip
[app]   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[app]   |   File "/venv/lib/python3.12/site-packages/oauth2_provider/views/base.py", line 18, in <module>
[app]   |     from ..models import get_access_token_model, get_application_model
[app]   |   File "/venv/lib/python3.12/site-packages/oauth2_provider/models.py", line 274, in <module>
[app]   |     class Application(AbstractApplication):
[app]   |   File "/venv/lib/python3.12/site-packages/django/db/models/base.py", line 134, in __new__
[app]   |     raise RuntimeError(
[app]   | RuntimeError: Model class oauth2_provider.models.Application doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

One way is to use lazy imports (move them to
`IDTokenAuthentication.authenticate_credentials`) for:
```
from oauth2_provider.views.mixins import OAuthLibMixin
from oauth2_provider.oauth2_validators import OAuth2Validator
```
as suggested here:
https://github.com/jazzband/django-oauth-toolkit/issues/719#issuecomment-544215436

This change solves the issue by adding a note about
`DJANGO_SETTINGS_MODULE` into `README.md`.
