### PR TITLE
Fix virtual env path environment variable in Dockerfile

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -73,15 +73,12 @@ WORKDIR ${app_path}
 ARG INSTALL_DEV_DEPS
 COPY requirements-dev.txt ${app_path}/
 RUN --mount=type=cache,target=${XDG_CACHE_HOME}/pip \
-    if [ ! -z "${INSTALL_DEV_DEPS}" ] ; then ${VENV_PATH}/bin/pip install -r ${app_path}/requirements-dev.txt ; fi
+    if [ ! -z "${INSTALL_DEV_DEPS}" ] ; then ${VIRTUAL_ENV}/bin/pip install -r ${app_path}/requirements-dev.txt ; fi
 
 #
 # Final image
 #
 FROM base AS final
-
-ENV VENV_PATH=/venv
-ENV PATH=${VENV_PATH}/bin:${PATH}
 
 COPY --from=builder /venv /venv
 # COPY --from=builder ${app_path}/node_modules ${app_path}/node_modules


### PR DESCRIPTION
Currently, docker build fails because `pip` is not found:
```
$ podman-compose  -f docker-compose.dev.yml  -f docker-compose.yml --podman-build-args="--security-opt label=disable" up --build --build-arg INSTALL_DEV_DEPS=0 --build-arg BUILD_ID=0
[3/4] STEP 13/13: RUN --mount=type=cache,target=${XDG_CACHE_HOME}/pip     if [ ! -z "${INSTALL_DEV_DEPS}" ] ; then ${VENV_PATH}/bin/pip install -r ${app_path}/requirements-dev.txt ; fi
/bin/sh: 1: /bin/pip: not found
Error: building at STEP "RUN --mount=type=cache,target=${XDG_CACHE_HOME}/pip if [ ! -z "${INSTALL_DEV_DEPS}" ] ; then ${VENV_PATH}/bin/pip install -r ${app_path}/requirements-dev.txt ; fi": while running runtime: exit status 127
```

The reason for this is that `VENV_PATH` is defined below it is used. The change leverages that `VIRTUAL_ENV` is already defined, and the fact that:

> A stage inherits any environment variables that were set using ENV by its parent stage or any ancestor.

(see: https://docs.docker.com/reference/dockerfile/#env)

The line with `PATH` is deleted because it is unnecessary because of the
same fact.

Note that I ran `podman-compose` because Fedora comes with `podman`, not `docker`, yet here the behavior of `podman` and `docker` are identical.