### PR TITLE
Fix Dockerfile ARG scope

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -73,15 +73,12 @@ WORKDIR ${app_path}
 ARG INSTALL_DEV_DEPS
 COPY requirements-dev.txt ${app_path}/
 RUN --mount=type=cache,target=${XDG_CACHE_HOME}/pip \
-    if [ ! -z "${INSTALL_DEV_DEPS}" ] ; then ${VENV_PATH}/bin/pip install -r ${app_path}/requirements-dev.txt ; fi
+    if [ ! -z "${INSTALL_DEV_DEPS}" ] ; then ${VIRTUAL_ENV}/bin/pip install -r ${app_path}/requirements-dev.txt ; fi
 
 #
 # Final image
 #
 FROM base AS final
-
-ENV VENV_PATH=/venv
-ENV PATH=${VENV_PATH}/bin:${PATH}
 
 COPY --from=builder /venv /venv
 # COPY --from=builder ${app_path}/node_modules ${app_path}/node_modules

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,12 +1,4 @@
 ARG base_image=debian:testing-slim
-
-FROM caddy:2 AS caddy
-
-#
-# Invocations common for builder and final stages
-#
-FROM ${base_image} AS base
-
 ARG runtime_deps="libpq5 postgresql-client gettext \
     libproj25 ^libgdal3[4567]$ libjpeg62-turbo libtiff6 libxml2 libffi8 libxslt1.1 \
     libwebp7 libvoikko1 voikko-fi curl libpcre3 \
@@ -16,10 +8,19 @@ ARG build_time_deps="libpq-dev build-essential \
     zlib1g-dev libjpeg-dev libtiff-dev libopenjp2-7-dev libwebp-dev \
     binutils libproj-dev libgdal-dev \
     libxml2-dev libxslt1-dev libffi-dev libpython3.12-dev"
-# ARG node_install_url="https://deb.nodesource.com/setup_lts.x"
 ARG app_path=/code
-ARG app_user_uid=1000
-ARG app_user_gid=1000
+
+FROM caddy:2 AS caddy
+
+#
+# Invocations common for builder and final stages
+#
+FROM ${base_image} AS base
+
+ARG runtime_deps
+ARG build_time_deps
+# ARG node_install_url="https://deb.nodesource.com/setup_lts.x"
+ARG app_path
 
 ENV VIRTUAL_ENV=/venv
 ENV PATH=/venv/bin:$PATH
@@ -43,6 +44,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Builder stage
 #
 FROM base AS builder
+
+ARG runtime_deps
+ARG build_time_deps
+ARG app_path
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -79,6 +84,9 @@ RUN --mount=type=cache,target=${XDG_CACHE_HOME}/pip \
 # Final image
 #
 FROM base AS final
+
+ARG app_user_uid=1000
+ARG app_user_gid=1000
 
 COPY --from=builder /venv /venv
 # COPY --from=builder ${app_path}/node_modules ${app_path}/node_modules


### PR DESCRIPTION
After applying changes from
https://github.com/kausaltech/kausal-paths/pull/46, Docker does not
build still.

```
$ podman-compose  -f docker-compose.dev.yml  -f docker-compose.yml --podman-build-args="--security-opt label=disable" up --build --build-arg INSTALL_DEV_DEPS=0 --build-arg BUILD_ID=0
[4/4] STEP 15/32: RUN groupadd -g ${app_user_gid} user && useradd --no-log-init -m -d /home/user -g ${app_user_gid} -u ${app_user_uid} -r user
groupadd: invalid group ID 'user'
Error: building at STEP "RUN groupadd -g ${app_user_gid} user && useradd --no-log-init -m -d /home/user -g ${app_user_gid} -u ${app_user_uid} -r user": while running runtime: exit status 3
```

The reason is incorrect scope for multiple `ARG`s:

> An ARG instruction goes out of scope at the end of the build stage
> where it was defined. To use an argument in multiple stages, each stage
> must include the ARG instruction.

(see: https://docs.docker.com/reference/dockerfile/#scope)

The change fixes the scope for all `ARG`s.

Note that I ran `podman-compose` because Fedora comes with `podman`, not
`docker`, yet here the behavior of `podman` and `docker` are identical.
