### PR TITLE
Load all DVC datasets on cache miss

### DIFF
--- a/nodes/context.py
+++ b/nodes/context.py
@@ -155,6 +155,8 @@ class Context:
         if ds is None:
             if not self.dataset_repo.has_dataset(ds_id):
                 raise Exception('Dataset %s not found in DVC repo' % ds_id)
+            if not self.dataset_repo.is_dataset_cached(ds_id):
+                self.load_all_dvc_datasets()
             with self.tracer.start_as_current_span('load dataset: %s' % ds_id):
                 ds = self.dataset_repo.load_dataset(ds_id)
             self.dvc_datasets[ds_id] = ds

--- a/requirements.txt
+++ b/requirements.txt
@@ -222,7 +222,7 @@ dvc-objects==5.1.0
     # via
     #   dvc
     #   dvc-data
-dvc-pandas==0.3.1
+dvc-pandas==0.3.2
     # via -r requirements.in
 dvc-render==1.0.2
     # via dvc


### PR DESCRIPTION
When trying to load any uncached dataset, this loads all DVC datasets so they are all cached and subsequent loads are faster.