### PR TITLE
Adding "oauth2_provider" to INSTALLED_APPS 

### DIFF
--- a/paths/settings.py
+++ b/paths/settings.py
@@ -139,6 +139,8 @@ INSTALLED_APPS = [
 
     'social_django',
 
+    'oauth2_provider',
+    
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION

Hi maintainers,

I am new to this repository and was attempting to set it up locally when I encountered an issue. Specifically, I received the following error:

```
RuntimeError: Model class oauth2_provider.models.Application doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

To resolve this, I have added `oauth2_provider` to the `INSTALLED_APPS` in the project settings. I hope this change helps improve the setup process for other newcomers.

Thank you for your consideration!

Best regards,  
Ibrahim

