### PR TITLE
Fix page translations

### DIFF
--- a/nodes/models.py
+++ b/nodes/models.py
@@ -354,6 +354,7 @@ class InstanceConfig(PathsModel, UUIDIdentifiedModel):  # , RevisionMixin)
         """Return root page in activated language, fall back to default language."""
         root: Page = self.root_page
         language = get_language()
+        language = convert_language_code(language, 'wagtail')
         try:
             locale = Locale.objects.get(language_code=language)
             root = root.get_translation(locale)  # type: ignore

--- a/pages/wagtail_hooks.py
+++ b/pages/wagtail_hooks.py
@@ -1,12 +1,18 @@
-from typing import Any
+from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+from django.db.models import Q
 from wagtail import hooks
-from wagtail.models import Page
 from wagtail.snippets.models import register_snippet
-from wagtail.query import PageQuerySet
 
 from pages.sitecontent import InstanceSiteContentViewSet
-from paths.types import PathsAdminRequest
+
+if TYPE_CHECKING:
+    from wagtail.models import Page
+    from wagtail.query import PageQuerySet
+
+    from paths.types import PathsAdminRequest
 
 
 @hooks.register('construct_explorer_page_queryset')
@@ -15,8 +21,11 @@ def filter_pages_to_admin_instance(
 ) -> PageQuerySet[Page]:
     ic = request.admin_instance
     assert ic.site is not None
-    instance_pages = ic.site.root_page.get_descendants(inclusive=True)
-    return pages.filter(id__in=instance_pages)
+
+    q = Q()
+    for page in ic.site.root_page.get_translations(inclusive=True):
+        q |= pages.descendant_of_q(page, inclusive=True)
+    return pages.filter(q)
 
 
 @hooks.register('construct_page_chooser_queryset')


### PR DESCRIPTION
Translated pages were not showing up in the admin UI, and the translated content didn't find its way to the UI. Fix the issues py taking translated pages into account in relevant queries and use correct format of the language code.