### PR TITLE
Set up email sending

### DIFF
--- a/paths/settings.py
+++ b/paths/settings.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 import environ
 from corsheaders.defaults import default_headers as default_cors_headers
 
+from kausal_common import ENV_SCHEMA as COMMON_ENV_SCHEMA, register_settings as register_common_settings
 from kausal_common.deployment import set_secret_file_vars
 from kausal_common.sentry.init import init_sentry
 
@@ -40,8 +41,6 @@ env = environ.FileAwareEnv(
     STATIC_URL=(str, '/static/'),
     SENTRY_DSN=(str, ''),
     COOKIE_PREFIX=(str, PROJECT_NAME),
-    SERVER_EMAIL=(str, 'noreply@kausal.tech'),
-    DEFAULT_FROM_EMAIL=(str, 'noreply@kausal.tech'),
     INTERNAL_IPS=(list, []),
     HOSTNAME_INSTANCE_DOMAINS=(list, ['localhost']),
     CONFIGURE_LOGGING=(bool, True),
@@ -62,6 +61,7 @@ env = environ.FileAwareEnv(
     GITHUB_APP_ID=(str, ''),
     GITHUB_APP_PRIVATE_KEY=(str, ''),
     MOUNTED_SECRET_PATHS=(list, []),
+    **COMMON_ENV_SCHEMA,
 )
 
 BASE_DIR = root()
@@ -469,6 +469,10 @@ WATCH_DEFAULT_API_BASE_URL = env('WATCH_DEFAULT_API_BASE_URL')
 # Information needed to authentiacte as a GitHub App
 GITHUB_APP_ID = env('GITHUB_APP_ID')
 GITHUB_APP_PRIVATE_KEY = env('GITHUB_APP_PRIVATE_KEY')
+
+register_common_settings(locals())
+# Put type hints for stuff registered in register_common_settings here because mypy doesn't figure it out
+# ...
 
 if find_spec('kausal_paths_extensions') is not None:
     INSTALLED_APPS.append('kausal_paths_extensions')

--- a/requirements.in
+++ b/requirements.in
@@ -72,3 +72,12 @@ diffsync
 django-pydantic-field
 graphene-pydantic
 xxhash
+# FIXME: We moved the email configuration to kausal-common. The django-anymail
+# requirements should ideally also be moved to
+# kausal_common/requirements-common.txt. However, this seems difficult at the
+# moment because projects using kausal-common may use different versions of
+# Django or other packages on which django-anymail depends. For the time being,
+# each project must declare these requirements separately.
+django-anymail[mailgun]
+django-anymail[sendgrid]
+django-anymail[mailjet]

--- a/requirements.txt
+++ b/requirements.txt
@@ -146,6 +146,7 @@ distro==1.9.0
 django==5.1.4
     # via
     #   -r requirements.in
+    #   django-anymail
     #   django-celery-results
     #   django-cors-headers
     #   django-extensions
@@ -169,6 +170,8 @@ django==5.1.4
     #   strawberry-graphql-django
     #   wagtail
     #   wagtail-localize
+django-anymail==12.0
+    # via -r requirements.in
 django-celery-results==2.5.1
     # via -r requirements.in
 django-cors-headers==4.6.0
@@ -653,6 +656,7 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.32.3
     # via
+    #   django-anymail
     #   django-oauth-toolkit
     #   dvc
     #   dvc-studio-client
@@ -685,6 +689,8 @@ ruamel-yaml==0.18.6
     #   dvc
     #   dvc-pandas
     #   gto
+ruamel-yaml-clib==0.2.12
+    # via ruamel-yaml
 s3cmd==2.4.0
     # via -r requirements.in
 s3fs==2024.10.0
@@ -763,6 +769,7 @@ typer==0.15.1
     # via gto
 typing-extensions==4.12.2
     # via
+    #   anyio
     #   asyncssh
     #   django-pydantic-field
     #   django-stubs-ext
@@ -773,6 +780,7 @@ typing-extensions==4.12.2
     #   jwcrypto
     #   opentelemetry-sdk
     #   pint
+    #   psycopg
     #   psycopg-pool
     #   pydantic
     #   pydantic-core
@@ -793,6 +801,7 @@ uritemplate==4.1.1
 urllib3==2.2.3
     # via
     #   botocore
+    #   django-anymail
     #   dulwich
     #   pygithub
     #   requests


### PR DESCRIPTION
This takes the email configuration into use that we [recently moved](https://github.com/kausaltech/kausal-backend-common/pull/7) from `kausal-watch-private` to `kausal-backend-common`.