### PR TITLE
Normalize dataset values to match dimension categories

### DIFF
--- a/frameworks/models.py
+++ b/frameworks/models.py
@@ -727,7 +727,10 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
             return [(u, None) for u in uuids]
 
         combinations = set()
-        for row in df.select(column_names).iter_rows():
+
+        df = df.select(column_names)
+        df = node.convert_names_to_ids(df)
+        for row in df.iter_rows():
             if row[0] is None:
                 continue
             combinations.add(row)

--- a/nodes/gpc.py
+++ b/nodes/gpc.py
@@ -167,7 +167,7 @@ class DatasetNode(AdditiveNode):
 
     # -----------------------------------------------------------------------------------
     def convert_names_to_ids(self, df: ppl.PathsDataFrame) -> ppl.PathsDataFrame:
-        exset = {YEAR_COLUMN, VALUE_COLUMN, FORECAST_COLUMN, UNCERTAINTY_COLUMN, 'Unit'}
+        exset = {YEAR_COLUMN, VALUE_COLUMN, FORECAST_COLUMN, UNCERTAINTY_COLUMN, 'Unit', 'UUID'}
 
         # Convert index level names from labels to IDs.
         collookup = {}


### PR DESCRIPTION
Without normalizing the values in the dataset, sometimes they will not match with the actual output dataframe used for retrieving the placeholder values.