### PR TITLE
In the admin UI create view, also create models related to schema

### DIFF
--- a/paths/dataset_config.py
+++ b/paths/dataset_config.py
@@ -8,7 +8,20 @@ dataset_config under the project directory.
 """
 from __future__ import annotations
 
+import typing
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from django.db.models import Model
+
+def schema_default_scope():
+    # Only call in view contexts where the context has been initialized
+    from paths.context import realm_context
+    return realm_context.get().realm
+
 DATASOURCE_DEFAULT_SCOPE_CONTENT_TYPE: tuple[str, str] =  ('nodes', 'instanceconfig')
 SCHEMA_HAS_SINGLE_DATASET: bool = True
+SCHEMA_DEFAULT_SCOPE_FUNCTION: Callable[[], Model] | None = schema_default_scope
 SHOW_DATASETS_IN_MENU: bool = True
 SHOW_SCHEMAS_IN_MENU: bool = False


### PR DESCRIPTION
Controlled by the dataset_config configuration variables, potentially also create a Dataset and DatasetSchemaScope objects when creating a DatasetSchema with the create view in the Admin UI. The latter is especially important to handle authorization correctly, while the former is required in Paths where a schema should always have a single corresponding dataset.