### PR TITLE
Hide snippets from all view breadcrumbs

### DIFF
--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -10,7 +10,17 @@ from django.db.models import Model, QuerySet
 from django.forms import BaseModelForm
 from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.snippets.views.chooser import ChooseResultsView, ChooseView, SnippetChooserViewSet
-from wagtail.snippets.views.snippets import CreateView, DeleteView, EditView, IndexView, SnippetViewSet
+from wagtail.snippets.views.snippets import (
+    CopyView,
+    CreateView,
+    DeleteView,
+    EditView,
+    HistoryView,
+    IndexView,
+    InspectView,
+    SnippetViewSet,
+    UsageView,
+)
 
 from kausal_common.admin_site.mixins import HideSnippetsFromBreadcrumbsMixin
 from kausal_common.models.permission_policy import ModelPermissionPolicy
@@ -102,7 +112,23 @@ class PathsCreateView(HideSnippetsFromBreadcrumbsMixin, CreateView[_ModelT, _For
         }
 
 
-class PathsIndexView(HideSnippetsFromBreadcrumbsMixin, IndexView):
+class PathsIndexView(HideSnippetsFromBreadcrumbsMixin, IndexView[_ModelT, _QS]):
+    pass
+
+
+class PathsUsageView(HideSnippetsFromBreadcrumbsMixin, UsageView):
+    pass
+
+
+class PathsHistoryView(HideSnippetsFromBreadcrumbsMixin, HistoryView):
+    pass
+
+
+class PathsCopyView(HideSnippetsFromBreadcrumbsMixin, CopyView[_ModelT, _FormT]):
+    pass
+
+
+class PathsInspectView(HideSnippetsFromBreadcrumbsMixin, InspectView):
     pass
 
 
@@ -140,10 +166,15 @@ class PathsChooserViewSet(SnippetChooserViewSet, Generic[_ModelT]):
 
 
 class PathsViewSet(Generic[_ModelT, _QS, _FormT], SnippetViewSet[_ModelT, _FormT]):
-    index_view_class: ClassVar = PathsIndexView
+    index_view_class: ClassVar = PathsIndexView[_ModelT, _QS]
     add_view_class: ClassVar = PathsCreateView[_ModelT, _FormT]
     edit_view_class: ClassVar = PathsEditView[_ModelT, _FormT]
-    delete_view_class: ClassVar = PathsDeleteView[_ModelT, _FormT]
+    delete_view_class: ClassVar = PathsDeleteView
+    usage_view_class: ClassVar = PathsUsageView
+    history_view_class: ClassVar = PathsHistoryView
+    copy_view_class: ClassVar = PathsCopyView
+    inspect_view_class: ClassVar = PathsInspectView
+
     add_to_admin_menu = True
     chooser_viewset_class = PathsChooserViewSet
 


### PR DESCRIPTION
Previous fix left some less used views unfixed, e.g. history view or usage view. Hide snippets from all possible views.