### PR TITLE
Disable Wagtail workflow

### DIFF
--- a/paths/settings.py
+++ b/paths/settings.py
@@ -460,6 +460,7 @@ WAGTAIL_EMAIL_MANAGEMENT_ENABLED = False
 WAGTAIL_PASSWORD_RESET_ENABLED = True
 WAGTAILADMIN_PERMITTED_LANGUAGES = list(LANGUAGES)
 WAGTAILEMBEDS_RESPONSIVE_HTML = True
+WAGTAIL_WORKFLOW_ENABLED = False
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash


### PR DESCRIPTION
This setting disables everything related to workflows, i.e. sending different types of content changes for moderator approval.

I'm under the impression we do not use workflows in Paths right now, is that correct? Setting this to `False` would then hide confusing actions related to workflows from admin UI.