### PR TITLE
Properly report error if is_staff is False

### DIFF
--- a/admin_site/api.py
+++ b/admin_site/api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
+from django.urls import resolve
 from django.utils.translation import gettext as _
 from rest_framework.decorators import api_view, authentication_classes, permission_classes, schema, throttle_classes
 from rest_framework.exceptions import ValidationError
@@ -33,12 +36,19 @@ def check_login_method(request):
         msg = _("No user found with this email address. Ask your administrator to create an account for you.")
         raise ValidationError(dict(detail=msg, code="no_user"))
 
-    if False:
-        # TODO: For OIDC IdP flows we might not need access to the admin to be able
-        # to let the login proceed. Disable the check for now.
-        if not user.can_access_admin():
-            msg = _("This user does not have access to admin.")
-            raise ValidationError(dict(detail=msg, code="no_admin_access"))
+    next_url_input = d.get('next')
+    resolved = None
+    if next_url_input:
+        next_url = urlparse(next_url_input)
+        resolved = resolve(next_url.path)
+
+    destination_is_public_site = resolved and (
+        resolved.url_name == 'authorize' and 'oauth2_provider' in resolved.app_names
+    )
+
+    if not destination_is_public_site and not user.can_access_admin():
+        msg = _("This user does not have access to admin.")
+        raise ValidationError(dict(detail=msg, code="no_admin_access"))
 
     if user.has_usable_password():
         method = 'password'


### PR DESCRIPTION
Previously, the can_access_admin check was disabled because of the need to allow logging in to public UIs (NZC) too.

However, now we distinguish between admin login and public site login so we can cleanly check the is_staff status instead of crashing when trying to load the admin UI.