### PR TITLE
Update Syke indicators nodes

### DIFF
--- a/configs/espoo-syke.yaml
+++ b/configs/espoo-syke.yaml
@@ -5,7 +5,7 @@ frameworks: [syke]
 site_url: https://espoo-syke.paths.kausal.tech
 dataset_repo:
   url: https://github.com/kausaltech/dvctest.git
-  commit: f47b07dcbd11c67003bba576beb71b46d91b6f2e
+  commit: dc07a6babb99e81a3694558f8f144425c4d0bee8
 name: Hiilineutraali Espoo 2030
 name_en: Carbon-neutral Espoo 2030
 owner: Espoon kaupunki

--- a/configs/frameworks/syke.yaml
+++ b/configs/frameworks/syke.yaml
@@ -657,7 +657,7 @@ nodes:
   name: Laidunnuksen päästöt
   output_nodes: [livestock_emissions]
   params:
-    sector: Maatalous|Maatalous|Maatalous|Kotieläimet|Laidunnus+HINKU
+    sector: Maatalous|Maatalous|Maatalous|Peltoviljely|Laidunnus+HINKU
   input_nodes: [all_alas_emissions]
   type: finland.syke.AlasEmissions
 - id: manure_treatment_emissions
@@ -758,8 +758,7 @@ nodes:
   name: Muiden F-kaasujen lähteiden päästöt
   output_nodes: [f_gases_emissions]
   params:
-    sector: Teollisuusprosessit|F-kaasut|F-kaasut|Muut F-kaasujen
-      lähteet|Muut F-kaasujen lähteet+HINKU
+    sector: Teollisuusprosessit|F-kaasut|F-kaasut|Muut F-kaasujen lähteet|Muut F-kaasujen lähteet+HINKU
   input_nodes: [all_alas_emissions]
   type: finland.syke.AlasEmissions
 
@@ -768,6 +767,6 @@ nodes:
   output_nodes: [net_emissions]
   color: '#7570b3'
   params:
-    sector: Kompensaatiot|Kompensaatiot|Tuulivoima|Tuulivoima|Tuulivoima+HINKU
+    sector: Kompensaatiot|Kompensaatiot|Päästöhyvitykset|Tuulivoima|Tuulivoima+HINKU
   input_nodes: [all_alas_emissions]
   type: finland.syke.AlasEmissions


### PR DESCRIPTION
The data format of Syke indicators has changes slightly, so the categorisations of the nodes had to be changed.

Also updated the Syke dataset.

See also: https://github.com/kausaltech/ghg-notebooks/pull/23