### PR TITLE
Fix people search

### DIFF
--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -6,11 +6,19 @@ from wagtail.snippets.models import register_snippet
 from paths.context import realm_context
 
 from admin_site.utils import SuperAdminOnlyMenuItem
-from admin_site.viewsets import PathsViewSet
+from admin_site.viewsets import PathsIndexView, PathsViewSet
 
 from . import chooser  # noqa: F401
 from .forms import PersonForm
 from .models import Person
+
+
+class PersonIndexView(PathsIndexView[Person]):
+    def search_queryset(self, queryset):
+       # Workaround to prevent Wagtail from looking for `path` (from Organization) in the search fields for Person
+        queryset = Person.objects.filter(id__in=queryset)
+
+        return super().search_queryset(queryset)
 
 
 class PersonSnippetViewSet(PathsViewSet):
@@ -24,6 +32,7 @@ class PersonSnippetViewSet(PathsViewSet):
     search_fields = ['first_name', 'last_name', 'email', 'title']
     list_per_page = 50
     list_display =  ['avatar', 'first_name', 'last_name', 'email', 'organization', 'title']
+    index_view_class = PersonIndexView
 
     def get_queryset(self, request):
         active_instance = realm_context.get().realm


### PR DESCRIPTION
Workaround to prevent wagtail to look for organizations field "path" when searching people in the index view

Fixes this: https://sentry.kausal.tech/organizations/kausal/issues/11187/?alert_rule_id=9&alert_type=issue&environment=production&notification_uuid=1f42b789-42a3-49c4-bc3f-806e02ba65ee&project=6&referrer=slack

This one broke the people search:
https://github.com/kausaltech/kausal-paths/commit/699c0c3d4fce3ab11961333ddffc33afab3b2e27