### PR TITLE
Update Espoo model

### DIFF
--- a/configs/espoo.yaml
+++ b/configs/espoo.yaml
@@ -4,7 +4,7 @@ supported_languages: [sv, en]
 site_url: https://espoo.paths.kausal.tech
 dataset_repo:
   url: https://github.com/kausaltech/dvctest.git
-  commit: 428b6c0879a556b5659117c27bdeb53b408799fd
+  commit: ad87fbd0868257633d36c439e1eed5feae6869cd
   dvc_remote: kausal-s3
 name_fi: Hiilineutraali Espoo 2030
 name_en: Carbon-neutral Espoo 2030
@@ -1554,7 +1554,7 @@ actions:
   input_datasets:
   - id: espoo/priorisoidut_toimet
     tags: [baseline]
-    forecast_from: 2024
+    forecast_from: 2025
     column: aktiviteetti
   output_nodes:
   - id: passenger_car_kilometers


### PR DESCRIPTION
I ended up making some updates to Espoo model thinking it would help with extracting HSY indicators values. That's not really the case but the changes should be useful anyway.

With these data and model updates:
- transport_emissions node shows historical data until 2024 now (instead of 1990)
- direct_electric_heating_emissions node shows historical data until 2024 (instead of 2022)