### PR TITLE
Hide Reports menu item

### DIFF
--- a/admin_site/wagtail_hooks.py
+++ b/admin_site/wagtail_hooks.py
@@ -84,6 +84,10 @@ hooks.register('register_admin_menu_item', register_instance_chooser)
 
 @hooks.register('construct_main_menu')
 def hide_snippets_menu_item(request, menu_items):
+    # Hide snippets menu item, because the word "snippet" is just confusing in
+    # our use case and grouping up all snippets (almost all our adminable models
+    # are implemented as snippets) under one menu item does not bring any value
+    # to us.
     menu_items[:] = [item for item in menu_items if item.name != 'snippets']
 
 @hooks.register('construct_main_menu')

--- a/admin_site/wagtail_hooks.py
+++ b/admin_site/wagtail_hooks.py
@@ -86,6 +86,14 @@ hooks.register('register_admin_menu_item', register_instance_chooser)
 def hide_snippets_menu_item(request, menu_items):
     menu_items[:] = [item for item in menu_items if item.name != 'snippets']
 
+@hooks.register('construct_main_menu')
+def hide_reports_menu_item(request, menu_items):
+    # Hide reports menu item, because the reports Wagtail automatically generates
+    # are not scoped to the instance. If needed, the reports could be customised,
+    # look for more info in Wagtail docs:
+    # https://docs.wagtail.org/en/v6.4.2/extending/adding_reports.html
+    menu_items[:] = [item for item in menu_items if item.name != 'reports']
+
 
 @hooks.register('construct_reports_menu')
 def patch_translations_report_menu_item(request: PathsAdminRequest, menu_items: list):


### PR DESCRIPTION
## Description
Hides the Reports menu item, because the default Wagtail reports are not scoped to the instance, showing users things they are not supposed to see.

As some extra housekeeping, adds a clarifying comment about the reasons for hiding the snippets menu item.

Reasoning for this available in [Asana](https://app.asana.com/1/1201243246741462/project/1210316211648413/task/1211463895206174?focus=true)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
[Asana](https://app.asana.com/1/1201243246741462/project/1210316211648413/task/1211463895206174?focus=true)

## Requirements, dependencies and related PRs
None

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
#### Manual testing instructions
See that the Reports menu item is not available on the side menu.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

-----

## Additional Notes
Some reasoning why this was done available on the Asana task and its comments!
