### PR TITLE
Fix miscellaneous things related to organization views

### DIFF
--- a/orgs/views.py
+++ b/orgs/views.py
@@ -10,7 +10,7 @@ from kausal_common.organizations.views import (
 
 from paths.context import realm_context
 
-from admin_site.viewsets import PathsCreateView, admin_req
+from admin_site.viewsets import PathsCreateView, PathsIndexView, admin_req
 from orgs.models import Organization
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class CreateChildNodeView(BaseCreateChildNodeView):
 
         return instance
 
-class OrganizationIndexView(BaseOrganizationIndexView):
+class OrganizationIndexView(BaseOrganizationIndexView, PathsIndexView):
     def get_list_more_buttons(self, instance: Organization):
         assert self.view_set is not None
         user = admin_req(self.request).user

--- a/orgs/wagtail_hooks.py
+++ b/orgs/wagtail_hooks.py
@@ -221,6 +221,6 @@ class OrganizationViewSet(PathsViewSet):
         qs = Organization.objects.qs.available_for_instance(active_instance)
         return qs
 
-# If kausal_watch_extensions is installed, an extended version of the view set is registered there
+# If kausal_paths_extensions is installed, an extended version of the view set is registered there
 if not find_spec('kausal_paths_extensions'):
     register_snippet(OrganizationViewSet)

--- a/orgs/wagtail_hooks.py
+++ b/orgs/wagtail_hooks.py
@@ -85,8 +85,8 @@ class OrganizationViewSet(PathsViewSet):
     add_view_class = OrganizationCreateView
     edit_view_class = OrganizationEditView
     delete_view_class = OrganizationDeleteView
-    search_fields = ['name', 'abbreviation']
-    list_display = ['name', 'parent','abbreviation']
+    search_fields = ['name']
+    list_display = ['name', 'parent']
     add_to_admin_menu = True
     menu_item_class = SuperAdminOnlyMenuItem
     add_child_url_name = 'add_child'
@@ -99,7 +99,6 @@ class OrganizationViewSet(PathsViewSet):
             help_text=pgettext_lazy('organization', 'Pick the main organization that this organization is part of'),
         ),
         # FieldPanel('logo'),
-        TranslatedFieldPanel('abbreviation'),
         # Don't allow editing identifiers at this point
         # CondensedInlinePanel('identifiers', panels=[
         #     FieldPanel('namespace'),


### PR DESCRIPTION
## Description
Fixes a couple of things related to organization views:
- hides "snippets" breadcrumb from listing view
- Removes "Short name" as editable field from edit view

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
Removing "short name": https://app.asana.com/1/1201243246741462/project/1210316211648413/task/1211450163112576?focus=true
Other things encountered while developing, no Asana tickets for those.

## Requirements, dependencies and related PRs
https://github.com/kausaltech/kausal-extensions/pull/145

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
#### Manual testing instructions
No special steps needed

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PR's e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
\-

## Additional Notes
\-


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Organization index now uses PathsIndexView; "abbreviation" removed from search, list display, and edit panels.
> 
> - **Admin/Wagtail — `Organization` views**:
>   - **Index view**: `OrganizationIndexView` now extends `PathsIndexView`; index buttons sourced via `view_set.get_index_view_buttons` using `admin_req` and `realm_context`.
>   - **Fields/UI**: remove `abbreviation` from `search_fields`, `list_display`, and `basic_panels`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77f9562801c99a8744f058aef18fecfa12cfae3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->