### PR TITLE
Remove duplicate menu items

### DIFF
--- a/frameworks/wagtail_admin.py
+++ b/frameworks/wagtail_admin.py
@@ -39,6 +39,9 @@ class SectionViewSet(PathsViewSet[Section, SectionQuerySet]):
     ]
     menu_item_class = AdminOnlyMenuItem
 
+    # This viewset is added to a group menu item, so no need to add it twice
+    add_to_admin_menu = False
+
     def get_queryset(self, request: HttpRequest) -> SectionQuerySet:
         return super().get_queryset(request).filter(depth__gte=2)
 
@@ -60,6 +63,9 @@ class MeasureTemplateViewSet(PathsViewSet[MeasureTemplate, QuerySet]):
     search_fields = ['name', 'section__name', 'uuid']
     inspect_view_enabled = False
     copy_view_enabled = False
+
+    # This viewset is added to a group menu item, so no need to add it twice
+    add_to_admin_menu = False
 
     menu_item_class = AdminOnlyMenuItem
 


### PR DESCRIPTION
Some menu items were added both to a group menu item and separatelu to the top-level menu. Remove the top-level menu items.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable top-level admin menu entries for `SectionViewSet` and `MeasureTemplateViewSet` to avoid duplicates with the group menu.
> 
> - **Admin (Wagtail)**:
>   - Set `add_to_admin_menu = False` in `SectionViewSet` and `MeasureTemplateViewSet` to rely on the `Frameworks` group menu and remove duplicate top-level items.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd0d249d0e403e72ca2760dbea15765d9e129bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->