### PR TITLE
Fix organization primary language in REST API

### DIFF
--- a/orgs/api.py
+++ b/orgs/api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from rest_framework import exceptions, serializers
 
@@ -11,6 +11,7 @@ from kausal_common.api.utils import register_view
 from kausal_common.models.general import public_fields
 
 from paths import permissions
+from paths.context import realm_context
 
 from nodes.models import InstanceConfig
 from orgs.models import Organization
@@ -26,17 +27,22 @@ all_views: list[RegisteredAPIView] = []
 class OrganizationSerializer(TreebeardModelSerializerMixin[Organization], serializers.ModelSerializer[Organization]):  # type: ignore[misc]
     uuid = serializers.UUIDField(required=False)
 
-    class Meta:  # type: ignore[override]
+    class Meta:
         model = Organization
         list_serializer_class = BulkListSerializer
         fields = public_fields(Organization)
+        extra_kwargs: ClassVar = {
+            # Allow omitting primary_language since it
+            # can then be taken from the plan
+            'primary_language': {'required': False},
+        }
 
     def create(self, validated_data):
-        # from paths.context import realm_context
+        ic = realm_context.get().realm
+        if 'primary_language' not in validated_data:
+            validated_data['primary_language'] = ic.primary_language
         instance = super().create(validated_data)
-        # # Add instance to active instance's related organizations
-        # request: PathsAdminRequest = self.context.get('request')
-        # ic = realm_context.get().realm
+        # TODO: Add instance to active instance's related organizations
         # ic.related_organizations.add(instance)
         return instance
 


### PR DESCRIPTION
## Description
A sibling commit to the one in Watch, make sure all Organizations' primary_languages are set according to the active instance when using the REST API (mostly the table editor)

## Screenshots/Videos (if applicable)
N/A

## Related issue
N/A


## Requirements, dependencies and related PRs
Please merge at the same time as https://github.com/kausaltech/kausal-backend-common/pull/88

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X ] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Save new organization in REST API. Open it in the Organization form. The form does not crash anymore.
    
### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

Please merge at the same time as https://github.com/kausaltech/kausal-backend-common/pull/88

-----
