### PR TITLE
Update the default framework config maximum baseline year

### DIFF
--- a/frameworks/models.py
+++ b/frameworks/models.py
@@ -104,7 +104,7 @@ class MinMaxDefaultInt(BaseModel):
 
 class FrameworkDefaults(BaseModel):
     target_year: MinMaxDefaultInt = MinMaxDefaultInt(min=2030, default=2030, max=2050)
-    baseline_year: MinMaxDefaultInt = MinMaxDefaultInt(min=2018, default=None, max=2023)
+    baseline_year: MinMaxDefaultInt = MinMaxDefaultInt(min=2018, default=None, max=2025)
 
 
 class Framework(CacheablePathsModel['FrameworkSpecificCache'], UUIDIdentifiedModel):
@@ -783,8 +783,7 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
         }
         year = self.baseline_year
         measure_data_points_qs = (
-            MeasureDataPoint.objects
-            .get_queryset()
+            MeasureDataPoint.objects.get_queryset()
             .filter(year=year, measure__in=measures_qs)
             .annotate(mt_uuid=F('measure__measure_template__uuid'))
         )


### PR DESCRIPTION
## Description
Update the default maximum baseline year for framework configs so that when creating a new plan in NetZeroPlanner, users can select up to 2025 as the instance baseline year. Plus some ruff autofixing.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Additional Notes
Any additional information that reviewers should know about this PR.
