### PR TITLE
Check active users before cluster login fallback

### DIFF
--- a/admin_site/api.py
+++ b/admin_site/api.py
@@ -62,7 +62,7 @@ def check_login_method(request):
     if not email:
         msg = _('Invalid email address')
         raise ValidationError(dict(detail=msg, code='invalid_email'))
-    user = User.objects.filter(email__iexact=email).first()
+    user = User.objects.filter(email__iexact=email, is_active=True).first()
     if user is None:
         cluster_result = check_user_in_other_clusters(email, request)
         if cluster_result:

--- a/admin_site/tests.py
+++ b/admin_site/tests.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from typing import Never
+
+from django.urls import reverse
+
 import pytest
 from social_core.backends.base import BaseAuth
 
 from paths.const import INSTANCE_SUPER_ADMIN_ROLE
 
+from admin_site.api import check_user_in_other_clusters
 from admin_site.auth_backends import NZCPortalOAuth2
 from admin_site.auth_pipeline import assign_roles
 from frameworks.models import FrameworkConfig
@@ -17,6 +22,82 @@ pytestmark = pytest.mark.django_db
 
 class DummyAuthBackend(BaseAuth):
     name = 'test'
+
+
+class DummyClusterResponse:
+    status_code = 200
+
+    def json(self) -> dict[str, str]:
+        return {'method': 'azure_ad'}
+
+
+def test_check_login_method_redirects_to_user_cluster(client, monkeypatch, settings) -> None:
+    settings.PATHS_BACKEND_REGION_URLS = ['https://eu.paths.example']
+    url = reverse('admin_check_login_method')
+
+    def post(url: str, json: dict[str, str], timeout: int, headers: dict[str, str]) -> DummyClusterResponse:
+        assert url == 'https://eu.paths.example/admin/login/check/'
+        assert json == {'email': 'user@example.com'}
+        assert timeout == 5
+        assert headers == {'Content-Type': 'application/json'}
+        return DummyClusterResponse()
+
+    monkeypatch.setattr('admin_site.api.requests.post', post)
+
+    response = client.post(url, {'email': ' USER@example.com '}, content_type='application/json')
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'method': 'azure_ad',
+        'cluster_redirect': True,
+        'cluster_url': 'https://eu.paths.example',
+    }
+
+
+def test_check_login_method_ignores_inactive_local_user_when_checking_clusters(client, monkeypatch, settings) -> None:
+    settings.PATHS_BACKEND_REGION_URLS = ['https://eu.paths.example']
+    UserFactory.create(email='user@example.com', is_staff=True, is_superuser=True, is_active=False)
+    url = reverse('admin_check_login_method')
+
+    def post(*_args: object, **_kwargs: object) -> DummyClusterResponse:
+        return DummyClusterResponse()
+
+    monkeypatch.setattr('admin_site.api.requests.post', post)
+
+    response = client.post(url, {'email': 'user@example.com'}, content_type='application/json')
+
+    assert response.status_code == 200
+    assert response.json()['cluster_redirect'] is True
+
+
+def test_check_login_method_prefers_local_user(client, monkeypatch, settings, instance_config) -> None:
+    settings.PATHS_BACKEND_REGION_URLS = ['https://eu.paths.example']
+    user = UserFactory.create(email='user@example.com', is_staff=True, is_superuser=True)
+    user.set_password('password')
+    user.save()
+    url = reverse('admin_check_login_method')
+
+    def post(*_args: object, **_kwargs: object) -> Never:
+        raise AssertionError('local users should not be checked from other clusters')
+
+    monkeypatch.setattr('admin_site.api.requests.post', post)
+
+    response = client.post(url, {'email': 'user@example.com'}, content_type='application/json')
+
+    assert response.status_code == 200
+    assert response.json() == {'method': 'password'}
+
+
+def test_check_user_in_other_clusters_skips_regional_host(rf, monkeypatch, settings) -> None:
+    settings.PATHS_BACKEND_REGION_URLS = ['https://regional.paths.example']
+    request = rf.post('/admin/login/check/', HTTP_HOST='regional.paths.example')
+
+    def post(*_args: object, **_kwargs: object) -> Never:
+        raise AssertionError('regional hosts should not check peer clusters')
+
+    monkeypatch.setattr('admin_site.api.requests.post', post)
+
+    assert check_user_in_other_clusters('user@example.com', request) is None
 
 
 def test_nzcportal_city_admin_maps_to_instance_super_admin() -> None:


### PR DESCRIPTION
Mirror the Kausal Watch login behavior by treating only active local accounts as local matches before trying configured regional backends. This lets users with inactive stale accounts in the current deployment still be redirected to the cluster where their active account lives.

Add focused admin login tests for remote-cluster redirects, inactive local account fallback, local-user precedence, and the guard that avoids peer checks when the current host is already a regional endpoint.

Note that, contrary to our assumption, most of the functionality for redirecting users was already in place in this repo.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Additional Notes
Any additional information that reviewers should know about this PR.
