### PR TITLE
Implement fault tolerance for the model graph

### DIFF
--- a/docs/architecture/fault-tolerance.md
+++ b/docs/architecture/fault-tolerance.md
@@ -1,0 +1,394 @@
+# Fault Tolerance in the Model Graph
+
+## Overview
+
+The model editor (Trailhead) lets people build a model instance
+incrementally: dragging in nodes, wiring edges, adjusting parameters.
+During this work the graph is routinely in a broken state — a node that
+isn't connected yet, a node whose `compute()` raises because a required
+input is missing, a cost subgraph that fails while the emissions
+subgraph is fine.
+
+The default engine is fail-fast: any exception during instance
+construction or node computation aborts the whole instance (see
+`InstanceLoader` and `Node._get_output_pl`). That is correct for
+production, but useless for an editor — one broken node would blank the
+entire model the user is trying to fix.
+
+This document describes an opt-in **tolerant mode** for draft models: a
+node that fails to construct or compute is quarantined, the healthy
+remainder of the graph still computes, and every failure is surfaced to
+the editor with enough attribution to point at the root cause.
+
+The guiding constraint: **a tolerant graph must never present a
+wrong-but-plausible number as authoritative.** A red node is honest; a
+silently-undercounted emissions figure is a correctness bug. Tolerance
+is therefore always visible (status is reported) and always unpublishable
+(see Scope).
+
+
+## Scope and guarantees
+
+- Tolerant behavior is **opt-in**, gated on a flag on `Context`. The
+  default computation path stays fail-fast, unchanged.
+- It applies to **draft models only**. A model snapshot that has any
+  node in a non-OK status **cannot be published**. This is what makes a
+  partial result safe: it is never the basis of a published scenario.
+- Node graphs are rebuilt per GraphQL request — `Context` and the `Node`
+  objects are ephemeral. Status therefore lives for the duration of one
+  request and needs no cross-request invalidation.
+
+
+## Node status
+
+Every node carries a status:
+
+```python
+class NodeStatus(Enum):
+    OK          # computed (or will compute) cleanly
+    INCOMPLETE  # not enough inputs wired yet — mid-construction, not an error
+    DEGRADED    # produced output, but from a partial input set
+    FAILED      # construction or compute failed; no usable output
+```
+
+`node.status is None` means "not determined yet" — the node has neither
+been validated nor pulled.
+
+| Status | Produces output? | Meaning |
+|---|---|---|
+| `None` | — | Not yet evaluated this request |
+| `OK` | yes | Healthy |
+| `INCOMPLETE` | empty (self-report only) | No / insufficient inputs wired |
+| `DEGRADED` | yes (partial) | Tolerated a missing/failed input |
+| `FAILED` | no | Own construction or compute failed |
+
+Within a single request, status only ever moves *toward* failure
+(`OK → DEGRADED → FAILED`), never back. Because each node computes at
+most once per request (results are cached) and a fresh graph is built for
+the next request, this monotonicity is essentially automatic; the setter
+enforces it as cheap insurance against an in-request double-set. A node
+fixed by the user "recovers" simply because the next request builds a new
+graph and re-evaluates from `None`.
+
+
+## When status is set
+
+Status is determined at the cheapest point that can determine it, in
+three tiers:
+
+1. **Construction time (metadata only).** Anything provable without
+   computing is stamped during instance load: missing required
+   parameters, incompatible units, dangling edge targets, dimension
+   requirements that no upstream can satisfy, and the unwired
+   (`INCOMPLETE`) case. This is the most valuable tier — it costs nothing
+   at compute time and catches the "just dropped a node in" case, the
+   most common ephemeral failure. The dimension-constraint propagation
+   described in [`dimension-constraints.md`](dimension-constraints.md) is
+   the detector for the shape-related failures here.
+
+   This tier lands together with the planned Spec-based graph
+   construction that will replace the current YAML/`InstanceLoader` path
+   (see the implementation plan). Until then, the unwired (`INCOMPLETE`)
+   case is caught at compute time — a tolerant `AdditiveNode` with no
+   available inputs marks itself `INCOMPLETE` — and richer metadata
+   validation is deferred rather than retrofitted onto `InstanceLoader`.
+
+2. **Compute time.** A node whose own `compute()` raises marks **its own**
+   status `FAILED` in the `except` block of `get_output_pl`, distinguishing
+   a node's own failure from an inherited cascade via
+   `NodeError.event_chain[0].node` (the origin). The status is memoized: a
+   subsequent `get_output_pl` for a node already `FAILED` (whether from
+   tier 1 or tier 2) short-circuits and re-signals failure **without
+   recomputing**. This matters for performance — a failed node consumed
+   by N downstream nodes fails once, not N times.
+
+   The memoization is **intentionally not scenario/parameter-scoped**:
+   `status` is a single per-object field, while the output cache is
+   scenario-keyed. So a node that fails under *any* scenario evaluated in
+   a request stays `FAILED` for the rest of that request, even if it would
+   succeed under a different scenario pulled later (e.g. baseline). This is
+   deliberate — a model under construction that breaks in one scenario
+   needs the developer's attention regardless, and scenario-scoping the
+   status would add needless complexity for no editor benefit.
+
+3. **Query time.** The editor reads each node's own `status` and `errors`
+   directly (see Reporting). Root-vs-cascade is derivable client-side
+   without a server-side walk: a *root* failure is a `FAILED` node with a
+   non-empty `errors` list; a *cascade* is a `FAILED` node with empty
+   `errors` (the real error lives on the upstream root). So the editor can
+   avoid lighting up forty nodes red without the server computing an
+   effective-status DAG walk.
+
+
+## Propagation: ports and edges
+
+Failure attribution lives at the **port**, not only the node. This
+mirrors the dimension architecture, and gives a clean duality:
+
+> Dimension **requirements** propagate *upstream* through ports and
+> edges; input **availability** propagates *downstream* through the same
+> ports and edges. Same topology, opposite directions.
+
+- **Port availability** (derived, consumer-side): an input port is
+  *unavailable* iff its upstream node is `FAILED` or `INCOMPLETE`. A
+  `DEGRADED` upstream is still *available* — it produced partial output;
+  the consumer ingests it and inherits `DEGRADED` via the query-time
+  walk.
+- **Edge status** (derived): the upstream node's status seen through the
+  edge. Nothing is stored on the edge — it is derived for rendering only.
+
+`InputPortDef.multi` (the multi-connection additive port) and
+`OutputPortDef.dimensions` (the declared output shape) are the spec-level
+anchors for this; see `nodes/defs/port_def.py`.
+
+
+## Tolerant computation
+
+The core rule for a tolerant consumer is **skip, don't sum**: an
+unavailable input is dropped from the computation entirely, exactly as if
+its edge did not exist — it is never ingested as an empty frame. This
+avoids dimension-alignment errors and keeps the partial result
+well-formed.
+
+### AdditiveNode
+
+`AdditiveNode` is the first (and, for now, only) node to opt into
+tolerance. The choice is principled, not arbitrary: its documented
+contract is already *"Missing values are assumed to be zero."* Treating a
+failed or unavailable input as a zero contribution is an **extension of
+behavior the node already promises**, not a new semantic. This is exactly
+why tolerance must *not* be generalized to nodes where missing ≠ zero —
+`SubtractiveNode`, division, or any node whose output changes
+non-trivially when an input vanishes would silently produce a
+*differently* wrong number with no contract to justify it.
+
+When a tolerant `AdditiveNode` skips one or more inputs, it marks its own
+status `DEGRADED`. The skipped inputs have already marked *themselves*
+`FAILED`/`INCOMPLETE`, so the consumer does not record anyone else's
+status — it only records its own.
+
+### add_nodes_pl
+
+The skip logic lives in the single existing input-fetch loop — one
+`get_output_pl` call per input, no probe pass. To avoid changing the
+return signature of `add_nodes_pl` (which has many callers), the body
+moves into a private implementation that always returns a count of
+skipped inputs, with two thin wrappers over it:
+
+```python
+def _add_nodes_impl(
+    self, df, nodes, ..., tolerate_failures: bool,
+) -> tuple[ppl.PathsDataFrame, int]:
+    ...
+    skipped = 0
+    for node, mult in pairs:          # multipliers paired up front
+        try:
+            node_df = node.get_output_pl(self, metric=metric)
+        except NodeError:
+            if not tolerate_failures:
+                raise
+            skipped += 1              # node self-marked; contributes zero
+            continue
+        node_outputs.append((node, node_df, mult))
+    ...
+    return df, skipped
+
+def add_nodes_pl(self, df, nodes, ...) -> ppl.PathsDataFrame:
+    out, _ = self._add_nodes_impl(df, nodes, ..., tolerate_failures=False)
+    return out
+
+def add_nodes_tolerant(self, df, nodes, ...) -> tuple[ppl.PathsDataFrame, int]:
+    return self._add_nodes_impl(df, nodes, ..., tolerate_failures=True)
+```
+
+Every current caller keeps `add_nodes_pl`'s `PathsDataFrame` return
+unchanged and stays fail-fast (`tolerate_failures=False`).
+`AdditiveNode` calls `add_nodes_tolerant` (only when the `Context` is in
+tolerant/draft mode) and uses the skip count to set its own status.
+
+Enabling the skip forces one cleanup: `node_multipliers` is currently
+popped positionally in lockstep with the node list. Skipping a node
+mid-loop would silently misalign multipliers, so the multipliers must be
+**paired with their nodes up front** (`zip(nodes, multipliers)`) rather
+than popped. This is a worthwhile fix regardless — the positional pop is
+a latent bug.
+
+If `df is None` and *every* input was skipped, the node falls through to
+the `INCOMPLETE` empty-output path rather than popping an empty list.
+
+### Empty output for INCOMPLETE nodes
+
+An `INCOMPLETE` node's `get_output` returns an empty frame. Its shape is
+the node's **declared** `OutputPortDef.dimensions` when present (empty
+rows, correct shape), falling back to dimensionless (year + value only)
+for a transparent node with no declared output dimensions — consistent
+with the additive rule that output dims are the union of input dims, which
+for zero inputs is empty.
+
+This empty output is a **self-report only** — what the editor shows when
+previewing that node directly. It is never an operand in a downstream
+sum, because tolerant consumers skip unavailable ports. So the dimension
+machinery never has to reconcile an empty/dimensionless frame against a
+dimensioned sibling.
+
+
+## Reporting
+
+`NodeEditorFields` (`nodes/graphql/types/node.py`) gains two fields for
+the editor:
+
+- `status: NodeStatus!` — the node's effective status (the query-time
+  ancestor-walk result).
+- `errors: [NodeError!]!` — the structured problems recorded *at this
+  node*. Empty for an OK node, and empty for a node that is only affected
+  via a cascade (its status reflects an upstream break, but the error
+  itself lives on the upstream node).
+
+The error type carries a few structured fields alongside the free-form
+message, so the editor can filter/group without parsing strings:
+
+```graphql
+enum NodeErrorPhase {
+  INITIALIZATION   # raised while constructing the node / wiring edges
+  COMPUTATION      # raised from compute()
+}
+
+type NodeError {
+  phase: NodeErrorPhase!
+  message: String!
+}
+```
+
+A node can hold several errors — initialization may surface multiple
+metadata-validation failures at once, whereas a compute failure yields a
+single entry. (Metadata validation reports under `INITIALIZATION`; a
+separate phase can be split out later if the editor needs the
+distinction.)
+
+Cascade attribution — which upstream node is the root cause of a blocked
+node — is recovered by walking ancestors to the nearest nodes that carry
+their own `errors`. The existing `NodeError` event chain
+(`add_node_event`) already records this path, so an `originNodeId` field
+can be added to `NodeError` later to expose it directly if the walk
+proves insufficient.
+
+The `DEGRADED` status itself distinguishes *this node tolerated a failed
+input* (set by the node from a non-zero skip count) from
+*inherited-degraded-from-upstream* (a node that is OK on its own but
+whose effective status is dragged down by the ancestor-walk) — the
+former is the more actionable badge, pointing at this node's own wiring.
+
+
+## Alternatives considered
+
+**Drop the failed node's output edges, leave everything else.** The
+original framing. Rejected as the primary mechanism: at compute time it
+doesn't rescue downstream (a node that lost a required input fails anyway,
+just differently), and for nodes that tolerate missing inputs it produces
+a *successful-but-wrong* number with no signal. Edge removal also
+destroys the declared topology the editor wants to draw. Replaced by node
+status + skip-don't-sum + query-time propagation, which keeps the
+topology and never fabricates a clean-looking wrong result.
+
+**Make tolerance the default compute path.** Rejected. A graph that
+silently amputates failing nodes and reports whatever's left is a
+correctness hazard the moment it backs a city's published scenario.
+Tolerance is gated and draft-only.
+
+**Generalize tolerance to all nodes.** Rejected. Only nodes whose
+contract is "missing input = zero contribution" (`AdditiveNode`) can drop
+an input without changing semantics. Applying it to subtraction,
+division, etc. would silently corrupt results.
+
+**Key status to the node hash (cache-invalidation scope).** Considered
+when we thought a parameter change might flip a node's status within a
+live graph. Unnecessary: `Context`/`Node` are rebuilt per GraphQL request,
+so status is naturally request-scoped and a fixed node recovers via the
+next request's fresh graph. Object-lifetime status is sufficient.
+
+**Pre-filter inputs by probing each one before summing.** Rejected: even
+with aggressive caching it means two `get_output` calls per input. The
+single try/except in the existing `add_nodes_pl` loop achieves the same
+with one call.
+
+**Store status on edges.** Rejected. Edge/port status is a pure function
+of the upstream node's status; derive it for rendering rather than storing
+and maintaining it (same discipline as removing the `side` field in the
+dimension work).
+
+
+---
+
+## Implementation plan (temporary — remove once landed)
+
+Status: steps 1–6 **landed** (engine + GraphQL reporting, with tests in
+`nodes/tests/test_fault_tolerance.py` and `test_model_editor.py`). Steps 7
+and the two wiring items below are **not yet done**.
+
+1. **`NodeStatus` enum + `Node.status` field.** Define `NodeStatus`
+   (`OK`, `INCOMPLETE`, `DEGRADED`, `FAILED`) and the `NodeErrorPhase`
+   enum + `NodeStatusError` record in `nodes/node.py` (small enough not to
+   warrant a separate module). Add `Node.status: NodeStatus | None = None`
+   and `Node.status_errors: list[NodeStatusError]`, plus a `mark_status`
+   helper that only moves toward failure (severity-ordered max), never
+   back, within the object's life.
+
+2. **Tolerant flag on `Context`.** A single boolean, default `False`,
+   threaded from the draft-editor entry point. Everything below is dormant
+   unless it is set.
+
+3. **Compute-time status (tier 2).** In `Node._get_output_pl`: on the
+   existing `except`, stamp `self.status = FAILED` before re-raising; at
+   the top, short-circuit if `status is FAILED`/`INCOMPLETE` (memoization,
+   no recompute). On success, stamp `OK`.
+
+4. **`add_nodes_pl` split.** Move the body into
+   `_add_nodes_impl(..., tolerate_failures) -> (df, skip_count)`; keep
+   `add_nodes_pl -> PathsDataFrame` and add
+   `add_nodes_tolerant -> (df, skip_count)` as wrappers. Pair multipliers
+   with nodes up front; skip inputs that raise `NodeError` when tolerant.
+   Verify `SubtractiveNode`/`SectorEmissions` and other callers are
+   unchanged.
+
+5. **`AdditiveNode` opt-in + empty output.** In tolerant mode, call
+   `add_nodes_tolerant`; mark `DEGRADED` when the skip count is > 0; mark
+   `INCOMPLETE` and emit the declared/dimensionless empty frame when it
+   has no available inputs. This is what catches the unwired-node case
+   until tier 1 exists.
+
+6. **Reporting via GraphQL.** `NodeStatus` and `NodeErrorPhase` are
+   registered as Strawberry enums (`@sb.enum` directly on the Python
+   enums). A `NodeError` GraphQL type (`phase`, `message`) is exposed, and
+   `NodeEditorFields` gained `status: NodeStatus` and `errors: [NodeError!]!`.
+   No server-side DAG walk: root-vs-cascade is derivable client-side from
+   `(status, errors)` as described under "Query time". *(Landed.)*
+
+7. **Publish guard.** Block publishing a snapshot when any node is non-OK.
+   *(Not yet done.)*
+
+**Remaining wiring (not yet done):**
+
+- **Enable tolerant mode per editor request.** `Context.tolerate_node_failures`
+  exists and the engine respects it, but nothing flips it on yet. The draft
+  editor's compute path must set it for draft instances (and never for
+  published ones). Until then the behavior is dormant.
+- **Drive computation to populate status.** `status` is `None` until a node
+  is pulled. The editor must trigger a compute (e.g. of the outcome nodes)
+  for the status/errors fields to be meaningful.
+
+**Deferred — not part of this work:**
+
+- **Construction-time status (tier 1).** Do **not** modify
+  `InstanceLoader`; it is slated for replacement by graph construction
+  directly from the Spec definitions, eliminating the YAML dict structure
+  altogether. Per-node construction tolerance and metadata validation
+  (units, dangling edges, dimension constraints) land as part of *that*
+  work, against the new loader. Before it exists, only tolerant
+  `AdditiveNode`s self-identify `INCOMPLETE`; other unwired nodes simply
+  surface as `FAILED` at compute time — still flagged, still
+  unpublishable.
+
+- **`get_input(port)` migration.** When the port-based input accessor
+  lands, move the skip-don't-sum logic out of `add_nodes_pl` into
+  `get_input`, generalize it to any tolerant node, and delete the
+  `add_nodes_pl` special-casing.

--- a/docs/architecture/fault-tolerance.md
+++ b/docs/architecture/fault-tolerance.md
@@ -366,12 +366,20 @@ and the two wiring items below are **not yet done**.
 7. **Publish guard.** Block publishing a snapshot when any node is non-OK.
    *(Not yet done.)*
 
+**Activation (landed).** The UI opts in per request via a
+`tolerateNodeFailures` flag on the `@context` input (and the `@instance`
+directive), defaulting to `false`. It is stashed on `PathsGraphQLContext`
+and threaded through `InstanceConfig.enter_instance_context(...)`, which
+sets `context.tolerate_node_failures` explicitly on every entry (so the
+flag never leaks across requests that reuse a cached instance). It is
+**not** yet auto-derived from `source == DRAFT`: all current public
+instances are de-facto draft (no published snapshots exist yet), so a
+DRAFT-implies-tolerant default would silently make every instance
+tolerant. Once the publishing workflow lands, the default can become
+`source == DRAFT`.
+
 **Remaining wiring (not yet done):**
 
-- **Enable tolerant mode per editor request.** `Context.tolerate_node_failures`
-  exists and the engine respects it, but nothing flips it on yet. The draft
-  editor's compute path must set it for draft instances (and never for
-  published ones). Until then the behavior is dormant.
 - **Drive computation to populate status.** `status` is `None` until a node
   is pulled. The editor must trigger a compute (e.g. of the outcome nodes)
   for the status/errors fields to be meaningful.

--- a/docs/architecture/fault-tolerance.md
+++ b/docs/architecture/fault-tolerance.md
@@ -237,12 +237,25 @@ dimensioned sibling.
 `NodeEditorFields` (`nodes/graphql/types/node.py`) gains two fields for
 the editor:
 
-- `status: NodeStatus!` — the node's effective status (the query-time
-  ancestor-walk result).
-- `errors: [NodeError!]!` — the structured problems recorded *at this
-  node*. Empty for an OK node, and empty for a node that is only affected
-  via a cascade (its status reflects an upstream break, but the error
-  itself lives on the upstream node).
+- `status(compute: Boolean! = false): NodeStatus` — the node's status,
+  `null` until evaluated.
+- `errors(compute: Boolean! = false): [NodeError!]!` — the structured
+  problems recorded *at this* node. Empty for an OK node, and empty for a
+  node only affected via a cascade (its status reflects an upstream break,
+  but the error itself lives on the upstream node).
+
+Both fields take a `compute` argument. With `compute: false` (the
+default) the resolver just reads what's already there — cheap, so the
+editor can fetch statuses for the whole graph in one fast query.
+Init-phase failures (metadata validation, once tier 1 lands) are known
+without computing and show up immediately; compute-phase status stays
+`null` until determined. With `compute: true`, the resolver runs
+`get_output_pl()` for that node if its status is still unknown (failures
+are swallowed — the node's status/errors are populated as a side effect).
+The UI uses this for a node-detail view, or as a deferred follow-up query
+("compute statuses for all nodes") after the main view has rendered, with
+a spinner while results stream in. Computing a node also stamps statuses
+on its whole upstream cone as a side effect, since pulling it pulls them.
 
 The error type carries a few structured fields alongside the free-form
 message, so the editor can filter/group without parsing strings:
@@ -359,9 +372,10 @@ and the two wiring items below are **not yet done**.
 6. **Reporting via GraphQL.** `NodeStatus` and `NodeErrorPhase` are
    registered as Strawberry enums (`@sb.enum` directly on the Python
    enums). A `NodeError` GraphQL type (`phase`, `message`) is exposed, and
-   `NodeEditorFields` gained `status: NodeStatus` and `errors: [NodeError!]!`.
-   No server-side DAG walk: root-vs-cascade is derivable client-side from
-   `(status, errors)` as described under "Query time". *(Landed.)*
+   `NodeEditorFields` gained `status(compute)` and `errors(compute)` (see
+   Reporting). No server-side DAG walk: root-vs-cascade is derivable
+   client-side from `(status, errors)` as described under "Query time".
+   *(Landed.)*
 
 7. **Publish guard.** Block publishing a snapshot when any node is non-OK.
    *(Not yet done.)*
@@ -378,11 +392,11 @@ DRAFT-implies-tolerant default would silently make every instance
 tolerant. Once the publishing workflow lands, the default can become
 `source == DRAFT`.
 
-**Remaining wiring (not yet done):**
-
-- **Drive computation to populate status.** `status` is `None` until a node
-  is pulled. The editor must trigger a compute (e.g. of the outcome nodes)
-  for the status/errors fields to be meaningful.
+**Drive computation to populate status (landed).** Status is `None` until
+a node is pulled, so the `status`/`errors` fields take a `compute`
+argument (see Reporting): `false` for a fast read of the whole graph,
+`true` to run `get_output_pl()` on demand (node-detail view, or a deferred
+"compute all" follow-up query). No separate compute endpoint is needed.
 
 **Deferred — not part of this work:**
 

--- a/docs/architecture/fault-tolerance.md
+++ b/docs/architecture/fault-tolerance.md
@@ -77,21 +77,37 @@ Status is determined at the cheapest point that can determine it, in
 three tiers:
 
 1. **Construction time (metadata only).** Anything provable without
-   computing is stamped during instance load: missing required
-   parameters, incompatible units, dangling edge targets, dimension
-   requirements that no upstream can satisfy, and the unwired
-   (`INCOMPLETE`) case. This is the most valuable tier — it costs nothing
-   at compute time and catches the "just dropped a node in" case, the
-   most common ephemeral failure. The dimension-constraint propagation
-   described in [`dimension-constraints.md`](dimension-constraints.md) is
-   the detector for the shape-related failures here.
+   computing is stamped during instance load: disallowed/unresolvable
+   parameters, invalid tags, bad visualizations, invalid action
+   metadata (decision level, group, parent), and unresolvable edges.
 
-   This tier lands together with the planned Spec-based graph
-   construction that will replace the current YAML/`InstanceLoader` path
-   (see the implementation plan). Until then, the unwired (`INCOMPLETE`)
-   case is caught at compute time — a tolerant `AdditiveNode` with no
-   available inputs marks itself `INCOMPLETE` — and richer metadata
-   validation is deferred rather than retrofitted onto `InstanceLoader`.
+   This is implemented in `InstanceLoader`: when `context.tolerate_node_failures`
+   is set (threaded in before construction, so the flag is live the moment
+   the `Context` is built), each metadata raise-site routes through
+   `InstanceLoader._init_failure(node, msg)`, which records a
+   `NodeStatusError(INITIALIZATION, …)` and `FAILED` status on the node and
+   continues, instead of aborting the load. The node keeps its **real
+   class** (so the editor renders it normally, just flagged) — only the
+   offending piece (param/edge/tag/viz) is skipped. In strict mode
+   `_init_failure` raises a structured `NodeError`; the plain
+   `Exception`/`TypeError` raises at these sites were converted to
+   `NodeError` so origin info reaches the UI uniformly.
+
+   **Scope:** this covers failures where the `Node` object already exists.
+   Failures *before* the object exists — node class not importable, no
+   unit/quantity, unparseable unit — and structural failures (duplicate
+   id, graph cycles) are **not** tolerated: the model editor's own
+   validation prevents those from being saved, so they can't reach a load.
+   They stay hard failures and are a deliberate non-goal for the
+   to-be-replaced loader. One known imperfection: some init errors (e.g. a
+   bad visualization) aren't actually fatal to computation, but we mark
+   `FAILED` anyway since there's no "warning" severity yet.
+
+   Note: this tier-1 work targets the current `InstanceLoader` on purpose
+   — to surface the metadata-error sites and learn from them before the
+   Spec-based loader replaces it. The dimension-constraint detector in
+   [`dimension-constraints.md`](dimension-constraints.md) will add
+   shape-related metadata validation as part of that rewrite.
 
 2. **Compute time.** A node whose own `compute()` raises marks **its own**
    status `FAILED` in the `except` block of `get_output_pl`, distinguishing
@@ -334,9 +350,10 @@ dimension work).
 
 ## Implementation plan (temporary — remove once landed)
 
-Status: steps 1–6 **landed** (engine + GraphQL reporting, with tests in
-`nodes/tests/test_fault_tolerance.py` and `test_model_editor.py`). Steps 7
-and the two wiring items below are **not yet done**.
+Status: steps 1–6 **landed** (compute-time engine, GraphQL reporting,
+activation, and construction-time/tier-1 tolerance in `InstanceLoader`),
+with tests in `nodes/tests/test_fault_tolerance.py` and
+`test_model_editor.py`. Step 7 (publish guard) is **not yet done**.
 
 1. **`NodeStatus` enum + `Node.status` field.** Define `NodeStatus`
    (`OK`, `INCOMPLETE`, `DEGRADED`, `FAILED`) and the `NodeErrorPhase`
@@ -398,17 +415,24 @@ argument (see Reporting): `false` for a fast read of the whole graph,
 `true` to run `get_output_pl()` on demand (node-detail view, or a deferred
 "compute all" follow-up query). No separate compute endpoint is needed.
 
+**Construction-time status / tier 1 (landed).** Implemented in
+`InstanceLoader` via `_init_failure` for the "node object already exists"
+metadata failures (params, tags, visualizations, action metadata, edges,
+subactions) — see "When status is set / tier 1". Deliberately scoped to
+the current loader (not deferred to the rewrite) to surface and learn from
+the metadata-error sites. Failures before the node exists (class import,
+unit/quantity) and structural failures (duplicate id, cycles) stay hard
+failures, since editor-side validation prevents them from being saved.
+
 **Deferred — not part of this work:**
 
-- **Construction-time status (tier 1).** Do **not** modify
-  `InstanceLoader`; it is slated for replacement by graph construction
-  directly from the Spec definitions, eliminating the YAML dict structure
-  altogether. Per-node construction tolerance and metadata validation
-  (units, dangling edges, dimension constraints) land as part of *that*
-  work, against the new loader. Before it exists, only tolerant
-  `AdditiveNode`s self-identify `INCOMPLETE`; other unwired nodes simply
-  surface as `FAILED` at compute time — still flagged, still
-  unpublishable.
+- **Shape/dimension metadata validation.** The dimension-constraint
+  detector ([`dimension-constraints.md`](dimension-constraints.md)) lands
+  with the Spec-based loader that replaces `InstanceLoader`.
+
+- **A non-fatal "warning" severity.** Some init errors (e.g. a bad
+  visualization) don't actually block computation but are currently marked
+  `FAILED`. A warning level would let those degrade more precisely.
 
 - **`get_input(port)` migration.** When the port-based input accessor
   lands, move the skip-don't-sum logic out of `add_nodes_pl` into

--- a/nodes/context.py
+++ b/nodes/context.py
@@ -140,6 +140,14 @@ class Context:
     compare_pipeline_compatibility: bool = False
     """If set, the pipeline-compatible nodes will be compared against their pipeline-originated output."""
 
+    tolerate_node_failures: bool = False
+    """If set, node computation failures are quarantined (recorded as node status) instead of
+    aborting the whole computation.
+
+    Only for draft models in the model editor; the default fail-fast path is unchanged. A snapshot
+    with any non-OK node must not be publishable. See ``docs/architecture/fault-tolerance.md``.
+    """
+
     instance: Instance
     """The computation model instance."""
 

--- a/nodes/exceptions.py
+++ b/nodes/exceptions.py
@@ -38,10 +38,10 @@ class NodeEvent:
 
 class NodeError(Exception):
     error_code: ClassVar[NodeErrorCode | None] = None
-    event_chain: list[NodeEvent] = []
+    event_chain: list[NodeEvent]
 
     def __init__(self, node: Node, msg: str, *args, event: str | None = None, target_node: Node | None = None, **kwargs):
-        self.event_chain.append(NodeEvent(node, event, target_node))
+        self.event_chain = [NodeEvent(node, event, target_node)]
         msg_with_id = 'Node %s: %s' % (node.id, msg)
         super().__init__(msg_with_id, *args, **kwargs)
 

--- a/nodes/graphql/types/node.py
+++ b/nodes/graphql/types/node.py
@@ -1,3 +1,4 @@
+import contextlib
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Optional  # pyright: ignore[reportDeprecated]
@@ -25,6 +26,7 @@ from nodes.actions.action import ActionNode
 from nodes.constants import DecisionLevel
 from nodes.defs import SimpleConfig
 from nodes.defs.node_defs import ActionConfig, FormulaConfig, NodeKind, NodeSpec, PipelineConfig
+from nodes.exceptions import NodeError
 from nodes.graph_layout import NodeGraphLayoutMeta
 from nodes.graphql.types import DatasetPortType
 from nodes.graphql.types.change_history import EditableEntity
@@ -181,20 +183,39 @@ class NodeErrorType:
     message: str
 
 
+def _maybe_compute_status(node: Node, compute: bool) -> None:
+    """
+    Trigger computation to determine a node's status, on explicit opt-in.
+
+    Init-phase failures are known without computing, so ``status`` is cheap by
+    default; pass ``compute=true`` (e.g. from a node-detail view) to actually run
+    ``get_output_pl()`` and surface a compute failure. A failure leaves the node's
+    status/errors populated, so the exception is swallowed here.
+    """
+    if not compute or node.status is not None:
+        return
+    # get_output_pl records FAILED status + the error on the node before raising, so we only
+    # need to suppress the exception here.
+    with contextlib.suppress(NodeError):
+        node.get_output_pl()
+
+
 @sb.type(name='NodeEditor')
 class NodeEditorFields:
     _node: sb.Private['Node']
 
     @sb.field
     @staticmethod
-    def status(root: 'NodeEditorFields') -> NodeStatus | None:
-        """Health of the node in the current (draft) computation; null until evaluated."""
+    def status(root: 'NodeEditorFields', compute: bool = False) -> NodeStatus | None:
+        """Health of the node; null until evaluated. Pass `compute: true` to run it now (may be slow)."""
+        _maybe_compute_status(root._node, compute)
         return root._node.status
 
     @sb.field
     @staticmethod
-    def errors(root: 'NodeEditorFields') -> list[NodeErrorType]:
-        """Problems recorded at this node (own errors only; a cascade-failed node has FAILED status but empty errors)."""
+    def errors(root: 'NodeEditorFields', compute: bool = False) -> list[NodeErrorType]:
+        """Problems recorded at this node (own errors only). Pass `compute: true` to run it now (may be slow)."""
+        _maybe_compute_status(root._node, compute)
         return [NodeErrorType(phase=e.phase, message=e.message) for e in root._node.status_errors]
 
     @sb.field(graphql_type=NodeSpecType | None)

--- a/nodes/graphql/types/node.py
+++ b/nodes/graphql/types/node.py
@@ -29,6 +29,7 @@ from nodes.graph_layout import NodeGraphLayoutMeta
 from nodes.graphql.types import DatasetPortType
 from nodes.graphql.types.change_history import EditableEntity
 from nodes.graphql.types.impact import get_impact_metric
+from nodes.node import NodeErrorPhase, NodeStatus
 from nodes.quantities import get_registry as get_quantity_registry
 from nodes.scenario import Scenario, ScenarioKind
 from params import Parameter
@@ -172,9 +173,29 @@ class NodeSpecType(StrawberryPydanticType[NodeSpec]):
         ]
 
 
+@sb.type(name='NodeError')
+class NodeErrorType:
+    """A problem recorded at a node during initialization or computation."""
+
+    phase: NodeErrorPhase
+    message: str
+
+
 @sb.type(name='NodeEditor')
 class NodeEditorFields:
     _node: sb.Private['Node']
+
+    @sb.field
+    @staticmethod
+    def status(root: 'NodeEditorFields') -> NodeStatus | None:
+        """Health of the node in the current (draft) computation; null until evaluated."""
+        return root._node.status
+
+    @sb.field
+    @staticmethod
+    def errors(root: 'NodeEditorFields') -> list[NodeErrorType]:
+        """Problems recorded at this node (own errors only; a cascade-failed node has FAILED status but empty errors)."""
+        return [NodeErrorType(phase=e.phase, message=e.message) for e in root._node.status_errors]
 
     @sb.field(graphql_type=NodeSpecType | None)
     @staticmethod

--- a/nodes/instance_loader.py
+++ b/nodes/instance_loader.py
@@ -562,7 +562,23 @@ class InstanceLoader:
             datasets.append(fds)
         return datasets
 
-    def _make_node_params(self, config: dict[str, Any], node: Node) -> None:  # noqa: C901, PLR0912
+    def _init_failure(self, node: Node, msg: str, *, cause: Exception | None = None) -> None:
+        """
+        Handle a node init-phase (construction) failure.
+
+        In tolerant (draft) mode, record the failure on the node and return so the caller can
+        skip the offending piece and keep loading the rest of the graph. Otherwise raise a
+        structured ``NodeError``. See ``docs/architecture/fault-tolerance.md``.
+        """
+        from nodes.node import NodeErrorPhase, NodeStatus, NodeStatusError
+
+        if self.context.tolerate_node_failures:
+            node.mark_status(NodeStatus.FAILED, NodeStatusError(phase=NodeErrorPhase.INITIALIZATION, message=msg))
+            self.logger.warning('Node %s failed to initialize: %s' % (node.id, msg))
+            return
+        raise NodeError(node, msg) from cause
+
+    def _make_node_params(self, config: dict[str, Any], node: Node) -> None:  # noqa: C901, PLR0912, PLR0915
         from params.base import Parameter
         from params.param import ReferenceParameter
 
@@ -579,7 +595,8 @@ class InstanceLoader:
 
             param_obj = class_allowed_params.get(param_id)
             if param_obj is None:
-                raise NodeError(node, 'Parameter %s not allowed by node class' % param_id)
+                self._init_failure(node, 'Parameter %s not allowed by node class' % param_id)
+                continue
             param_class = type(param_obj)
 
             label = make_trans_string(pc, 'label', pop=True, required=False) or param_obj.label
@@ -592,10 +609,11 @@ class InstanceLoader:
             if ref is not None:
                 target = self.context.global_parameters.get(ref)
                 if target is None:
-                    raise NodeError(node, 'Parameter %s refers to an unknown global parameter: %s' % (param_id, ref))
+                    self._init_failure(node, 'Parameter %s refers to an unknown global parameter: %s' % (param_id, ref))
+                    continue
 
                 if not isinstance(target, param_class):
-                    raise NodeError(
+                    self._init_failure(
                         node,
                         'Node requires parameter of type %s, but referenced parameter %s is %s'
                         % (
@@ -604,6 +622,7 @@ class InstanceLoader:
                             type(target),
                         ),
                     )
+                    continue
                 ref_param = ReferenceParameter(
                     local_id=param_obj.local_id,
                     label=param_obj.label,
@@ -634,13 +653,18 @@ class InstanceLoader:
             try:
                 if value is not None:
                     param.value = param.clean(value)
-            except:
-                self.instance.log.error('Error setting parameter %s for node %s' % (param.local_id, node.id))
-                raise
+            except Exception as e:
+                self._init_failure(node, 'Error setting parameter %s: %s' % (param.local_id, e), cause=e)
+                continue
 
             for scenario_id, value in scenario_values.items():
+                try:
+                    cleaned = param.clean(value)
+                except Exception as e:
+                    self._init_failure(node, 'Invalid scenario value for parameter %s: %s' % (param.local_id, e), cause=e)
+                    continue
                 sv = self._scenario_values.setdefault(scenario_id, list())
-                sv.append((param, param.clean(value)))
+                sv.append((param, cleaned))
 
     def _make_node_visualizations(self, node: Node, config: list[dict[str, Any]]) -> None:
         from nodes.visualizations import NodeVisualizations
@@ -649,7 +673,8 @@ class InstanceLoader:
         try:
             node.visualizations = NodeVisualizations.model_validate(config, context=ctx)
         except Exception as e:
-            raise NodeError(node, 'Error validating visualizations') from e
+            # Tolerant mode leaves visualizations at their default (a node without viz config is fine).
+            self._init_failure(node, 'Error validating visualizations: %s' % e, cause=e)
 
     def make_node(  # noqa: C901, PLR0912, PLR0915
         self, node_class: type[Node], config: dict[str, Any], _yaml_lc: LineCol | None = None
@@ -736,10 +761,10 @@ class InstanceLoader:
         if isinstance(tags, str):
             tags = [tags]
         if tags:
-            for tag in tags:
-                if not isinstance(tag, str):
-                    raise NodeError(node, "'tags' must be a list of strings")
-            node.tags.update(tags)
+            if all(isinstance(tag, str) for tag in tags):
+                node.tags.update(tags)
+            else:
+                self._init_failure(node, "'tags' must be a list of strings")
 
         viz_config = config.get('visualizations')
         if viz_config:
@@ -895,17 +920,16 @@ class InstanceLoader:
                         node.decision_level = val
                         break
                 else:
-                    raise Exception('Invalid decision level for action %s: %s' % (nc['id'], decision_level))
+                    self._init_failure(node, 'Invalid decision level: %s' % decision_level)
 
             ag_id = nc.get('group', None)
             if ag_id is not None:
                 assert isinstance(ag_id, str)
-                for ag in self.instance.action_groups:
-                    if ag.id == ag_id:
-                        break
+                ag = next((ag for ag in self.instance.action_groups if ag.id == ag_id), None)
+                if ag is None:
+                    self._init_failure(node, "Action group '%s' not found" % ag_id)
                 else:
-                    raise Exception("Action group '%s' not found for action %s" % (ag_id, nc['id']))
-                node.group = ag
+                    node.group = ag
 
             parent_id = nc.get('parent', None)
             if parent_id is not None:
@@ -919,19 +943,21 @@ class InstanceLoader:
 
         ctx = self.context
         for node in ctx.nodes.values():
-            try:
-                for ec in self._output_nodes.get(node.id, []):
+            for ec in self._output_nodes.get(node.id, []):
+                try:
                     edge = Edge.from_config(ec, node=node, is_output=True, context=ctx)
                     node.add_edge(edge)
                     edge.output_node.add_edge(edge)
+                except Exception as e:
+                    self._init_failure(node, 'Invalid output edge: %s' % e, cause=e)
 
-                for ec in self._input_nodes.get(node.id, []):
+            for ec in self._input_nodes.get(node.id, []):
+                try:
                     edge = Edge.from_config(ec, node=node, is_output=False, context=ctx)
                     node.add_edge(edge)
                     edge.input_node.add_edge(edge)
-            except Exception:
-                self.logger.error('Error setting up edges for node %s' % node)
-                raise
+                except Exception as e:
+                    self._init_failure(node, 'Invalid input edge: %s' % e, cause=e)
 
     def _setup_subactions(self) -> None:
         from nodes.actions.action import ActionNode
@@ -941,9 +967,15 @@ class InstanceLoader:
         for parent_id, subs in self._subactions.items():
             parent = ctx.nodes.get(parent_id)
             if parent is None:
-                raise Exception("Action parent '%s' not found" % parent_id)
+                # No parent node to attribute to; record on each subaction that references it.
+                for sub_id in subs:
+                    sub = ctx.nodes.get(sub_id)
+                    if sub is not None:
+                        self._init_failure(sub, "Parent action '%s' not found" % parent_id)
+                continue
             if not isinstance(parent, ParentActionNode):
-                raise TypeError("Action '%s' is marked as a parent but is not a ParentActionNode" % parent_id)
+                self._init_failure(parent, "Action '%s' is marked as a parent but is not a ParentActionNode" % parent_id)
+                continue
             for sub_id in subs:
                 node = ctx.get_node(sub_id)
                 assert isinstance(node, ActionNode)
@@ -1151,13 +1183,24 @@ class InstanceLoader:
         )
 
     @classmethod
-    def from_yaml(cls, filename: Path, fw_config: FrameworkConfig | None = None) -> Self:
+    def from_yaml(
+        cls,
+        filename: Path,
+        fw_config: FrameworkConfig | None = None,
+        tolerate_node_failures: bool = False,
+    ) -> Self:
         yaml_fn = filename.resolve()
         yaml_conf = InstanceYAMLConfig.load_for_entrypoint(yaml_fn)
 
         data = yaml_conf.data
         assert data is not None
-        return cls(config=data, yaml_file_path=yaml_fn, fw_config=fw_config, config_mtime_hash=yaml_conf.meta.mtime_hash)
+        return cls(
+            config=data,
+            yaml_file_path=yaml_fn,
+            fw_config=fw_config,
+            config_mtime_hash=yaml_conf.meta.mtime_hash,
+            tolerate_node_failures=tolerate_node_failures,
+        )
 
     def __init__(
         self,
@@ -1165,6 +1208,7 @@ class InstanceLoader:
         yaml_file_path: Path | None = None,
         fw_config: FrameworkConfig | None = None,
         config_mtime_hash: str | None = None,
+        tolerate_node_failures: bool = False,
     ):
         from .units import add_unit_translations
 
@@ -1172,6 +1216,7 @@ class InstanceLoader:
         self.yaml_file_path = yaml_file_path.absolute() if yaml_file_path else None
         self.config = config
         self.fw_config = fw_config
+        self.tolerate_node_failures = tolerate_node_failures
         self.default_language = config['default_language']
         self.other_languages = config.get('supported_languages', [])
         self.config_mtime_hash = config_mtime_hash
@@ -1296,6 +1341,9 @@ class InstanceLoader:
                 sample_size=sample_size,
             )
         self.instance.set_context(self.context)
+        # Make the fault-tolerance flag available throughout construction (setup_nodes/edges),
+        # not just at compute time. See docs/architecture/fault-tolerance.md.
+        self.context.tolerate_node_failures = self.tolerate_node_failures
 
         # Store input and output node configs for each created node, to be used in setup_edges().
         self._input_nodes = {}

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -943,11 +943,16 @@ class InstanceConfig(
     def enter_instance_context(
         self,
         source: PreferredInstanceSource = PreferredInstanceSource.DRAFT,
+        tolerate_node_failures: bool = False,
     ):
         if self.identifier in _pytest_instances:
             instance = _pytest_instances[self.identifier]
         else:
             instance = self._initialize_instance(node_refs=True, source=source)
+
+        # Set explicitly every time (default False) so the flag never leaks across requests
+        # that reuse a cached instance/context. See docs/architecture/fault-tolerance.md.
+        instance.context.tolerate_node_failures = tolerate_node_failures
 
         token = instance_context.set(instance)
         try:
@@ -961,11 +966,15 @@ class InstanceConfig(
     async def enter_instance_context_async(
         self,
         source: PreferredInstanceSource = PreferredInstanceSource.DRAFT,
+        tolerate_node_failures: bool = False,
     ):
         if self.identifier in _pytest_instances:
             instance = _pytest_instances[self.identifier]
         else:
             instance = await sync_to_async(self._initialize_instance)(node_refs=True, source=source)
+
+        # Set explicitly every time (default False) so the flag never leaks across requests.
+        instance.context.tolerate_node_failures = tolerate_node_failures
 
         token = instance_context.set(instance)
         try:

--- a/nodes/models.py
+++ b/nodes/models.py
@@ -871,6 +871,7 @@ class InstanceConfig(
         self,
         node_refs: bool = False,
         source: PreferredInstanceSource | Literal['draft', 'published'] = PreferredInstanceSource.DRAFT,
+        tolerate_node_failures: bool = False,
     ) -> Instance:
         from .instance_loader import InstanceLoader
 
@@ -889,7 +890,7 @@ class InstanceConfig(
             from .instance_from_db import serialize_instance_to_dict
 
             config = serialize_instance_to_dict(self)
-            loader = InstanceLoader(config=config)
+            loader = InstanceLoader(config=config, tolerate_node_failures=tolerate_node_failures)
             instance = loader.instance
             self.update_instance_from_configs(instance, node_refs=True)
             return instance
@@ -904,7 +905,7 @@ class InstanceConfig(
             if config_fn is None:
                 raise ValueError(f'No YAML config entrypoint found for instance {self.identifier}')
             self.log.debug('Creating instance from YAML file: %s' % config_fn)
-            loader = InstanceLoader.from_yaml(config_fn)
+            loader = InstanceLoader.from_yaml(config_fn, tolerate_node_failures=tolerate_node_failures)
             instance = loader.instance
             with sentry_sdk.start_span(name='update-instance-from-configs: %s' % self.identifier, op='function'):
                 # We only need to do this on the plain old YAML path
@@ -916,6 +917,7 @@ class InstanceConfig(
         self,
         node_refs: bool = False,
         source: PreferredInstanceSource = PreferredInstanceSource.DRAFT,
+        tolerate_node_failures: bool = False,
     ) -> Instance:
         self.log.info(
             'Creating new instance from %s (source=%s)'
@@ -926,7 +928,11 @@ class InstanceConfig(
         )
 
         with sentry_sdk.start_span(name='create-instance-from-config: %s' % self.identifier, op='function'):
-            instance = self._create_from_config(node_refs=node_refs, source=source)
+            instance = self._create_from_config(
+                node_refs=node_refs,
+                source=source,
+                tolerate_node_failures=tolerate_node_failures,
+            )
 
         instance.modified_at = timezone.now()
         if settings.ENABLE_PERF_TRACING:
@@ -948,7 +954,7 @@ class InstanceConfig(
         if self.identifier in _pytest_instances:
             instance = _pytest_instances[self.identifier]
         else:
-            instance = self._initialize_instance(node_refs=True, source=source)
+            instance = self._initialize_instance(node_refs=True, source=source, tolerate_node_failures=tolerate_node_failures)
 
         # Set explicitly every time (default False) so the flag never leaks across requests
         # that reuse a cached instance/context. See docs/architecture/fault-tolerance.md.
@@ -971,7 +977,11 @@ class InstanceConfig(
         if self.identifier in _pytest_instances:
             instance = _pytest_instances[self.identifier]
         else:
-            instance = await sync_to_async(self._initialize_instance)(node_refs=True, source=source)
+            instance = await sync_to_async(self._initialize_instance)(
+                node_refs=True,
+                source=source,
+                tolerate_node_failures=tolerate_node_failures,
+            )
 
         # Set explicitly every time (default False) so the flag never leaks across requests.
         instance.context.tolerate_node_failures = tolerate_node_failures

--- a/nodes/node.py
+++ b/nodes/node.py
@@ -4,8 +4,10 @@ import typing
 # import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, ClassVar, Literal, Self, overload
 
+import strawberry as sb
 from django.utils.translation import gettext_lazy as _
 
 import numpy as np
@@ -67,6 +69,52 @@ if typing.TYPE_CHECKING:
     from .scenario import Scenario
 
 import polars as pl
+
+
+@sb.enum
+class NodeStatus(Enum):
+    """
+    Health of a node within a single (per-request, ephemeral) computation graph.
+
+    See ``docs/architecture/fault-tolerance.md``. Within one request a node's
+    status only ever moves toward failure (see ``Node.mark_status``); a fresh
+    graph is built per request, so a node fixed by the user "recovers" simply by
+    being re-evaluated from scratch in the next request.
+    """
+
+    OK = 'ok'
+    DEGRADED = 'degraded'
+    """Produced output, but from a partial input set (a tolerant node dropped a failed/unavailable input)."""
+    INCOMPLETE = 'incomplete'
+    """Not enough inputs wired to compute — mid-construction, not an error."""
+    FAILED = 'failed'
+    """Construction or computation failed; no usable output."""
+
+
+# Severity ordering for the monotonic status transition (higher = worse).
+_NODE_STATUS_SEVERITY: dict[NodeStatus, int] = {
+    NodeStatus.OK: 0,
+    NodeStatus.DEGRADED: 1,
+    NodeStatus.INCOMPLETE: 2,
+    NodeStatus.FAILED: 3,
+}
+
+
+@sb.enum
+class NodeErrorPhase(Enum):
+    """The phase in which a node-level error occurred (reported to the editor)."""
+
+    INITIALIZATION = 'initialization'
+    COMPUTATION = 'computation'
+
+
+@dataclass
+class NodeStatusError:
+    """A structured problem recorded at a node, surfaced via ``NodeEditorFields``."""
+
+    phase: NodeErrorPhase
+    message: str
+
 
 DEBUG_NODE_EXCEPTIONS = env_bool('DEBUG_NODE_EXCEPTIONS', default=False)
 
@@ -283,6 +331,12 @@ class Node:
 
     allow_nulls: bool
     'If the node allows null values in the output'
+
+    status: NodeStatus | None
+    'Health status within the current (per-request) computation graph; None until evaluated.'
+
+    status_errors: list[NodeStatusError]
+    'Structured problems recorded at this node (own errors only, not inherited cascades).'
 
     tags: set[str]
     'Tags to differentiate between multiple input/output nodes'
@@ -528,6 +582,8 @@ class Node:
         self._baseline_values = None
         self.parameters = {}
         self.tags = set()
+        self.status = None
+        self.status_errors = []
 
         kls = type(self)
         self.logger = context.log.bind(node=self.id, node_class='%s.%s' % (kls.__module__, kls.__qualname__))
@@ -1123,6 +1179,19 @@ class Node:
         if dim_ids != node_dims and not getattr(self, 'allow_unknown_dimensions', None):
             raise NodeError(self, 'Output has unknown dimensions: %s (expecting %s)' % (', '.join(dim_ids), ', '.join(node_dims)))
 
+    def mark_status(self, status: NodeStatus, error: NodeStatusError | None = None) -> None:
+        """
+        Record the node's status, only ever moving toward failure.
+
+        Status is monotonic within the node's (per-request) lifetime: a more
+        severe status replaces a less severe one, never the reverse. An optional
+        structured error is appended. See ``docs/architecture/fault-tolerance.md``.
+        """
+        if error is not None:
+            self.status_errors.append(error)
+        if self.status is None or _NODE_STATUS_SEVERITY[status] > _NODE_STATUS_SEVERITY[self.status]:
+            self.status = status
+
     def get_output(self, target_node: Node | None = None, metric: str | None = None) -> pd.DataFrame:
         df = self.get_output_pl(target_node, metric)
         return df.to_pandas()
@@ -1165,9 +1234,21 @@ class Node:
             try:
                 df, cache_res = self._get_output_pl(target_node=target_node, metric=metric, skip_dim_test=skip_dim_test)
             except Exception as e:
+                first_failure = self.status is not NodeStatus.FAILED
                 if isinstance(e, NodeError):
+                    # Record an own-error only if this node is where the error originated; an
+                    # inherited cascade leaves the error on the upstream node (event_chain[0]).
+                    own_error = first_failure and bool(e.event_chain) and e.event_chain[0].node is self
+                    self.mark_status(
+                        NodeStatus.FAILED,
+                        NodeStatusError(phase=NodeErrorPhase.COMPUTATION, message=str(e)) if own_error else None,
+                    )
                     e.add_node_event(self, event='get_output', target_node=target_node)
                     raise
+                self.mark_status(
+                    NodeStatus.FAILED,
+                    NodeStatusError(phase=NodeErrorPhase.COMPUTATION, message=str(e)) if first_failure else None,
+                )
                 raise NodeComputationError(self, 'Error getting output', event='get_output', target_node=target_node) from e
 
             if span is not None:
@@ -1189,12 +1270,16 @@ class Node:
 
         return df
 
-    def _get_output_pl(  # noqa: C901
+    def _get_output_pl(  # noqa: C901, PLR0912
         self,
         target_node: Node | None = None,
         metric: str | None = None,
         skip_dim_test: bool = False,
     ) -> tuple[ppl.PathsDataFrame, CacheResult[ppl.PathsDataFrame] | None]:
+        if self.status is NodeStatus.FAILED:
+            # Memoized failure: a node that already failed in this run is not recomputed.
+            raise NodeError(self, 'Node failed earlier in this computation run', event='compute', target_node=target_node)
+
         use_cache = not (self.disable_cache or self.context.skip_cache)
         cache_res = None
         if use_cache:
@@ -1217,11 +1302,17 @@ class Node:
                 df = ppl.from_pandas(df)
 
             self.validate_output(df)
-            if cache_res is not None:
+            # mark_status keeps any DEGRADED/INCOMPLETE a tolerant node set during compute().
+            self.mark_status(NodeStatus.OK)
+            # Cache only clean results: a cross-request cache hit must never read back as OK
+            # a node that actually computed DEGRADED/INCOMPLETE (those are deliberately not cached).
+            if cache_res is not None and self.status is NodeStatus.OK:
                 self.hasher.cache_output(cache_res, df)
         else:
             assert cache_res.obj is not None
             df = cache_res.obj
+            # Only OK results are cached, so a hit means the node was healthy.
+            self.mark_status(NodeStatus.OK)
 
         assert isinstance(df, ppl.PathsDataFrame)
 
@@ -1543,7 +1634,7 @@ class Node:
         ctx = {'node.id': self.id}
         self.context.warning('%s %s' % (str(self), msg), depth=depth + 1, **ctx, **kwargs)
 
-    def add_nodes_pl(  # noqa: C901, PLR0912, PLR0915
+    def _add_nodes_impl(  # noqa: C901, PLR0912, PLR0915
         self,
         df: ppl.PathsDataFrame | None,
         nodes: list[Node],
@@ -1553,11 +1644,29 @@ class Node:
         unit: Unit | None = None,
         start_from_year: int | None = None,
         ignore_unit: bool = False,
-    ) -> ppl.PathsDataFrame:
-        if len(nodes) == 0:
+        *,
+        tolerate_failures: bool = False,
+    ) -> tuple[ppl.PathsDataFrame | None, int]:
+        """
+        Sum the outputs of ``nodes`` (plus an optional input ``df``) together.
+
+        Shared implementation behind ``add_nodes_pl`` and ``add_nodes_tolerant``.
+        When ``tolerate_failures`` is set, inputs whose upstream node failed or is
+        INCOMPLETE are skipped (treated as a zero contribution) and counted; the
+        returned df is ``None`` only when nothing at all could be produced (no
+        dataset and every input unavailable). See
+        ``docs/architecture/fault-tolerance.md``.
+        """
+        # Pair each multiplier with its node up front, so skipping a node keeps the rest aligned.
+        apply_mult = bool(node_multipliers)
+        mults = node_multipliers if node_multipliers is not None else [1.0] * len(nodes)
+
+        if not nodes:
             if df is None:
+                if tolerate_failures:
+                    return None, 0
                 raise NodeError(self, 'No input dataset and no input nodes')
-            return df
+            return df, 0
         if self.debug:
             print('%s: input dataset:' % str(self.id))
             if df is not None:
@@ -1565,25 +1674,39 @@ class Node:
             else:
                 print('\tNo input dataset')
 
-        node_outputs: list[tuple[Node, ppl.PathsDataFrame]] = []
-        for node in nodes:
-            node_df = node.get_output_pl(self, metric=metric)
+        node_outputs: list[tuple[Node, ppl.PathsDataFrame, float]] = []
+        skipped = 0
+        for node, mult in zip(nodes, mults, strict=True):
+            try:
+                node_df = node.get_output_pl(self, metric=metric)
+            except NodeError:
+                if not tolerate_failures:
+                    raise
+                skipped += 1
+                continue
+            if tolerate_failures and node.status is NodeStatus.INCOMPLETE:
+                # An INCOMPLETE upstream produces an empty self-report only; treat it as absent.
+                skipped += 1
+                continue
             if start_from_year is not None:
                 node_df = node_df.filter(pl.col(YEAR_COLUMN) >= start_from_year)
             if node_df.paths.index_has_duplicates():
                 raise NodeError(self, "Input from node '%s' has duplicate index rows" % node.id)
             if keep_nodes:
                 node_df = node_df.with_columns(pl.lit(node.id).alias(NODE_COLUMN)).add_to_index(NODE_COLUMN)
-            node_outputs.append((node, node_df))
+            node_outputs.append((node, node_df, mult))
+
+        if df is None and not node_outputs:
+            # No input dataset and every input node was unavailable (tolerant mode only).
+            return None, skipped
 
         if df is None:
-            node, df = node_outputs.pop(0)
+            node, df, first_mult = node_outputs.pop(0)
             if self.debug:
                 print('%s: adding output from node %s' % (self.id, node.id))
                 self.print(df)
-            if node_multipliers:
-                mult = node_multipliers.pop(0)
-                df = df.with_columns(pl.col(VALUE_COLUMN) * mult)
+            if apply_mult:
+                df = df.with_columns(pl.col(VALUE_COLUMN) * first_mult)
         elif keep_nodes:
             df = df.with_columns(pl.lit('').alias(NODE_COLUMN)).add_to_index(NODE_COLUMN)
 
@@ -1600,7 +1723,7 @@ class Node:
             df = df.ensure_unit(VALUE_COLUMN, unit)
 
         meta = df.get_meta()
-        for node, node_df in node_outputs:
+        for node, node_df, mult in node_outputs:
             if self.debug:
                 print('%s: adding output from node %s' % (self.id, node.id))
                 self.print(node_df)
@@ -1608,8 +1731,7 @@ class Node:
             if VALUE_COLUMN not in node_df.columns:
                 raise NodeError(self, 'Value column missing in output of %s' % node.id)
 
-            if node_multipliers:
-                mult = node_multipliers.pop(0)
+            if apply_mult:
                 node_df = node_df.with_columns(pl.col(VALUE_COLUMN) * mult)  # noqa: PLW2901
 
             ndf_meta = node_df.get_meta()
@@ -1618,7 +1740,61 @@ class Node:
             df = df.paths.add_with_dims(node_df, how='outer')
 
         df = df.select([YEAR_COLUMN, *meta.dim_ids, VALUE_COLUMN, FORECAST_COLUMN])
-        return df
+        return df, skipped
+
+    def add_nodes_pl(
+        self,
+        df: ppl.PathsDataFrame | None,
+        nodes: list[Node],
+        metric: str | None = None,
+        keep_nodes: bool = False,
+        node_multipliers: list[float] | None = None,
+        unit: Unit | None = None,
+        start_from_year: int | None = None,
+        ignore_unit: bool = False,
+    ) -> ppl.PathsDataFrame:
+        out, _ = self._add_nodes_impl(
+            df,
+            nodes,
+            metric=metric,
+            keep_nodes=keep_nodes,
+            node_multipliers=node_multipliers,
+            unit=unit,
+            start_from_year=start_from_year,
+            ignore_unit=ignore_unit,
+            tolerate_failures=False,
+        )
+        assert out is not None  # the non-tolerant path raises rather than returning None
+        return out
+
+    def add_nodes_tolerant(
+        self,
+        df: ppl.PathsDataFrame | None,
+        nodes: list[Node],
+        metric: str | None = None,
+        keep_nodes: bool = False,
+        node_multipliers: list[float] | None = None,
+        unit: Unit | None = None,
+        start_from_year: int | None = None,
+        ignore_unit: bool = False,
+    ) -> tuple[ppl.PathsDataFrame | None, int]:
+        """
+        Like ``add_nodes_pl``, but skip inputs whose upstream node failed or is INCOMPLETE.
+
+        Returns ``(df, skip_count)``; ``df`` is ``None`` if nothing could be produced (no
+        dataset and every input node unavailable). See ``docs/architecture/fault-tolerance.md``.
+        """
+        return self._add_nodes_impl(
+            df,
+            nodes,
+            metric=metric,
+            keep_nodes=keep_nodes,
+            node_multipliers=node_multipliers,
+            unit=unit,
+            start_from_year=start_from_year,
+            ignore_unit=ignore_unit,
+            tolerate_failures=True,
+        )
 
     def multiply_nodes_pl(
         self,

--- a/nodes/simple.py
+++ b/nodes/simple.py
@@ -16,7 +16,7 @@ from params.param import BoolParameter, NumberParameter, StringParameter
 
 from .constants import FORECAST_COLUMN, MIX_QUANTITY, VALUE_COLUMN, YEAR_COLUMN
 from .exceptions import NodeError
-from .node import InputPortMultiplicityHint, Node, NodeMetric
+from .node import InputPortMultiplicityHint, Node, NodeMetric, NodeStatus
 from .pipeline.compat import PipelineCompatibleNode
 
 if TYPE_CHECKING:
@@ -335,6 +335,23 @@ Missing values are assumed to be zero.""")
             df = extend_last_historical_value_pl(df, self.get_end_year())
         return df
 
+    def _empty_output(self) -> ppl.PathsDataFrame:
+        """
+        Build an empty (zero-row) but schema-valid output for an INCOMPLETE node.
+
+        Used when the node has no available inputs (e.g. not wired up yet). The frame
+        is dimensionless — a transparent additive node with no inputs has no categorical
+        dimensions. See ``docs/architecture/fault-tolerance.md``.
+        """
+        schema: dict[str, Any] = {YEAR_COLUMN: pl.Int64}
+        units = {}
+        for m in self.output_metrics.values():
+            schema[m.column_id] = pl.Float64
+            units[m.column_id] = m.unit
+        schema[FORECAST_COLUMN] = pl.Boolean
+        meta = ppl.DataFrameMeta(units=units, primary_keys=[YEAR_COLUMN])
+        return ppl.to_ppdf(pl.DataFrame(schema=schema), meta=meta)
+
     def compute(self) -> ppl.PathsDataFrame:
         idf = self.get_input_dataset_pl(required=False)
         metric = self.get_parameter_value_str('metric', required=False)
@@ -345,15 +362,32 @@ Missing values are assumed to be zero.""")
         na_nodes = self.get_input_nodes(tag='non_additive')
         input_nodes = [node for node in self.input_nodes if node not in na_nodes]
 
-        if self.get_parameter_value('use_input_node_unit_when_adding', required=False):
+        if self.get_parameter_value('use_input_node_unit_when_adding', required=False) and self.input_nodes:
             unit = self.input_nodes[0].unit
         else:
             unit = self.unit
+
+        tolerant = self.context.tolerate_node_failures
+        skipped = 0
         if self.get_parameter_value('fill_gaps_using_input_dataset', required=False):
-            df = self.add_nodes_pl(None, input_nodes, metric, unit=unit)
-            df = self.fill_gaps_using_input_dataset_pl(df)
+            if tolerant:
+                df, skipped = self.add_nodes_tolerant(None, input_nodes, metric, unit=unit)
+            else:
+                df = self.add_nodes_pl(None, input_nodes, metric, unit=unit)
+            if df is not None:
+                df = self.fill_gaps_using_input_dataset_pl(df)
+        elif tolerant:
+            df, skipped = self.add_nodes_tolerant(idf, input_nodes, metric, unit=unit)
         else:
             df = self.add_nodes_pl(idf, input_nodes, metric, unit=unit)
+
+        if df is None:
+            # No input dataset and every input node unavailable: the node isn't wired up yet.
+            self.mark_status(NodeStatus.INCOMPLETE)
+            return self._empty_output()
+        if skipped:
+            self.mark_status(NodeStatus.DEGRADED)
+
         df = self.maybe_drop_nulls(df)  # FIXME Check where this should be done.
         if self.get_parameter_value('drop_nans', required=False):  # FIXME: Implement this in the same way as drop_nulls
             df = df.filter(~pl.col(VALUE_COLUMN).is_nan())

--- a/nodes/tests/test_fault_tolerance.py
+++ b/nodes/tests/test_fault_tolerance.py
@@ -6,13 +6,14 @@ See ``docs/architecture/fault-tolerance.md``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from factory import Sequence
 
 from nodes.edges import Edge
 from nodes.exceptions import NodeError
+from nodes.instance_loader import InstanceLoader
 from nodes.node import NodeErrorPhase, NodeStatus, NodeStatusError
 from nodes.simple import AdditiveNode, SimpleNode
 from nodes.tests.factories import InstanceConfigFactory, InstanceFactory, NodeFactory
@@ -166,6 +167,62 @@ def test_enter_instance_context_defaults_to_fail_fast():
     ic = _instance_config()
     with ic.enter_instance_context() as instance:
         assert instance.context.tolerate_node_failures is False
+
+
+# --- construction-time (init-phase) tolerance --------------------------------
+
+
+def _loader_config(nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        'id': 'ft_test',
+        'default_language': 'en',
+        'supported_languages': [],
+        'name': 'Fault tolerance test',
+        'owner': 'Owner',
+        'target_year': 2030,
+        'minimum_historical_year': 2010,
+        'maximum_historical_year': 2020,
+        'reference_year': 1990,
+        'nodes': nodes,
+    }
+
+
+def _node_cfg(node_id: str, **extra: Any) -> dict[str, Any]:
+    return {'id': node_id, 'type': 'nodes.simple.AdditiveNode', 'name': node_id, 'unit': 'kWh', 'quantity': 'energy', **extra}
+
+
+def test_construction_tolerates_bad_param():
+    config = _loader_config([
+        _node_cfg('good'),
+        _node_cfg('bad', params=[{'id': 'this_param_does_not_exist', 'value': 1}]),
+    ])
+    ctx = InstanceLoader(config=config, tolerate_node_failures=True).context
+
+    assert ctx.nodes['bad'].status is NodeStatus.FAILED
+    assert any(e.phase is NodeErrorPhase.INITIALIZATION for e in ctx.nodes['bad'].status_errors)
+    # The rest of the graph still loaded, and the healthy node isn't flagged at init.
+    assert ctx.nodes['good'].status is None
+
+
+def test_construction_tolerates_bad_edge():
+    config = _loader_config([
+        _node_cfg('good'),
+        _node_cfg('dangling', output_nodes=['nonexistent_node']),
+    ])
+    ctx = InstanceLoader(config=config, tolerate_node_failures=True).context
+
+    assert ctx.nodes['dangling'].status is NodeStatus.FAILED
+    assert any(e.phase is NodeErrorPhase.INITIALIZATION for e in ctx.nodes['dangling'].status_errors)
+    assert 'good' in ctx.nodes
+
+
+def test_construction_strict_mode_still_raises():
+    config = _loader_config([
+        _node_cfg('good'),
+        _node_cfg('bad', params=[{'id': 'this_param_does_not_exist', 'value': 1}]),
+    ])
+    with pytest.raises(NodeError):
+        InstanceLoader(config=config, tolerate_node_failures=False)
 
 
 # --- editor status field: opt-in compute ------------------------------------

--- a/nodes/tests/test_fault_tolerance.py
+++ b/nodes/tests/test_fault_tolerance.py
@@ -1,0 +1,202 @@
+"""
+Tests for the draft-model fault-tolerance behavior.
+
+See ``docs/architecture/fault-tolerance.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from factory import Sequence
+
+from nodes.edges import Edge
+from nodes.exceptions import NodeError
+from nodes.node import NodeErrorPhase, NodeStatus, NodeStatusError
+from nodes.simple import AdditiveNode, SimpleNode
+from nodes.tests.factories import NodeFactory
+
+if TYPE_CHECKING:
+    from nodes.context import Context
+
+pytestmark = pytest.mark.django_db
+
+
+class _BoomNode(SimpleNode):
+    """A node whose computation always fails, counting how often it is attempted."""
+
+    def compute(self):
+        self.compute_calls = getattr(self, 'compute_calls', 0) + 1
+        raise NodeError(self, 'boom')
+
+
+class AdditiveNodeFactory(NodeFactory):
+    class Meta:
+        model = AdditiveNode
+
+    # Distinct id namespace: each factory subclass has its own Sequence counter, so a shared
+    # 'node{i}' prefix would let two nodes collide on id (and thus on cache key) across factories.
+    id = Sequence(lambda i: f'additive{i}')
+
+
+class BoomNodeFactory(NodeFactory):
+    class Meta:
+        model = _BoomNode
+
+    id = Sequence(lambda i: f'boom{i}')
+
+
+def _leaf(context: Context) -> AdditiveNode:
+    """Make an additive leaf fed by the factory's fixed dataset (computes cleanly)."""
+    return cast('AdditiveNode', AdditiveNodeFactory.create(context=context))
+
+
+def _sum_of(context: Context, inputs) -> AdditiveNode:
+    """Make an additive node with no dataset that sums the given input nodes."""
+    node = cast('AdditiveNode', AdditiveNodeFactory.create(context=context, input_datasets=[]))
+    for inp in inputs:
+        # Register the shared edge on both nodes, as the instance loader does.
+        edge = Edge(input_node=inp, output_node=node, tags=[])
+        node.add_edge(edge)
+        inp.add_edge(edge)
+    context.finalize_nodes()
+    return node
+
+
+# --- mark_status (monotonic, never recovers within a run) -------------------
+
+
+def test_mark_status_only_moves_toward_failure(node):
+    assert node.status is None
+    node.mark_status(NodeStatus.OK)
+    assert node.status is NodeStatus.OK
+    node.mark_status(NodeStatus.DEGRADED)
+    assert node.status is NodeStatus.DEGRADED
+    # A less-severe status does not override a more-severe one.
+    node.mark_status(NodeStatus.OK)
+    assert node.status is NodeStatus.DEGRADED
+    node.mark_status(NodeStatus.FAILED)
+    assert node.status is NodeStatus.FAILED
+    node.mark_status(NodeStatus.OK)
+    assert node.status is NodeStatus.FAILED
+
+
+def test_mark_status_records_error(node):
+    err = NodeStatusError(phase=NodeErrorPhase.COMPUTATION, message='kaboom')
+    node.mark_status(NodeStatus.FAILED, err)
+    assert node.status is NodeStatus.FAILED
+    assert node.status_errors == [err]
+
+
+# --- compute-time status ----------------------------------------------------
+
+
+def test_clean_node_marked_ok(context):
+    leaf = _leaf(context)
+    leaf.get_output_pl()
+    assert leaf.status is NodeStatus.OK
+    assert leaf.status_errors == []
+
+
+def test_failed_node_records_own_error(context):
+    boom = BoomNodeFactory.create(context=context)
+    with pytest.raises(NodeError):
+        boom.get_output_pl()
+    assert boom.status is NodeStatus.FAILED
+    assert len(boom.status_errors) == 1
+    assert boom.status_errors[0].phase is NodeErrorPhase.COMPUTATION
+
+
+def test_failure_is_memoized_not_recomputed(context):
+    boom = cast('_BoomNode', BoomNodeFactory.create(context=context))
+    for _ in range(3):
+        with pytest.raises(NodeError):
+            boom.get_output_pl()
+    # The failing compute() ran only once; later pulls short-circuit on FAILED status.
+    assert boom.compute_calls == 1
+
+
+def test_downstream_cascade_has_no_own_error(context):
+    boom = BoomNodeFactory.create(context=context)
+    consumer = _sum_of(context, [boom])
+    with pytest.raises(NodeError):
+        consumer.get_output_pl()
+    assert consumer.status is NodeStatus.FAILED
+    # The error originated upstream, so the consumer carries status but no own error.
+    assert consumer.status_errors == []
+    assert boom.status is NodeStatus.FAILED
+    assert len(boom.status_errors) == 1
+
+
+# --- non-tolerant (default) keeps failing fast ------------------------------
+
+
+def test_default_mode_propagates_failure(context):
+    boom = BoomNodeFactory.create(context=context)
+    good = _leaf(context)
+    summed = _sum_of(context, [good, boom])
+    assert context.tolerate_node_failures is False
+    with pytest.raises(NodeError):
+        summed.get_output_pl()
+
+
+def test_default_mode_unwired_additive_raises(context):
+    node = AdditiveNodeFactory.create(context=context, input_datasets=[])
+    context.finalize_nodes()
+    with pytest.raises(NodeError):
+        node.get_output_pl()
+
+
+# --- tolerant mode ----------------------------------------------------------
+
+
+def test_tolerant_additive_skips_failed_input(context):
+    context.tolerate_node_failures = True
+    good = _leaf(context)
+    boom = BoomNodeFactory.create(context=context)
+    summed = _sum_of(context, [good, boom])
+
+    df = summed.get_output_pl()
+    expected = good.get_output_pl()
+
+    assert summed.status is NodeStatus.DEGRADED
+    assert boom.status is NodeStatus.FAILED
+    # The partial sum equals the one surviving input.
+    assert df['Value'].to_list() == expected['Value'].to_list()
+
+
+def test_tolerant_unwired_additive_is_incomplete(context):
+    context.tolerate_node_failures = True
+    node = AdditiveNodeFactory.create(context=context, input_datasets=[])
+    context.finalize_nodes()
+
+    df = node.get_output_pl()
+    assert node.status is NodeStatus.INCOMPLETE
+    assert len(df) == 0
+    assert 'Value' in df.columns
+    assert df.has_unit('Value')
+
+
+def test_tolerant_all_inputs_failed_is_incomplete(context):
+    context.tolerate_node_failures = True
+    boom = BoomNodeFactory.create(context=context)
+    summed = _sum_of(context, [boom])
+
+    df = summed.get_output_pl()
+    assert summed.status is NodeStatus.INCOMPLETE
+    assert len(df) == 0
+
+
+def test_incomplete_input_skipped_by_consumer(context):
+    context.tolerate_node_failures = True
+    good = _leaf(context)
+    unwired = AdditiveNodeFactory.create(context=context, input_datasets=[])
+    summed = _sum_of(context, [good, unwired])
+
+    df = summed.get_output_pl()
+    expected = good.get_output_pl()
+    # The unwired (INCOMPLETE) input is treated as absent, not summed as an empty frame.
+    assert unwired.status is NodeStatus.INCOMPLETE
+    assert summed.status is NodeStatus.DEGRADED
+    assert df['Value'].to_list() == expected['Value'].to_list()

--- a/nodes/tests/test_fault_tolerance.py
+++ b/nodes/tests/test_fault_tolerance.py
@@ -168,6 +168,34 @@ def test_enter_instance_context_defaults_to_fail_fast():
         assert instance.context.tolerate_node_failures is False
 
 
+# --- editor status field: opt-in compute ------------------------------------
+
+
+def test_maybe_compute_status_is_noop_without_opt_in(context):
+    from nodes.graphql.types.node import _maybe_compute_status
+
+    boom = BoomNodeFactory.create(context=context)
+    _maybe_compute_status(boom, compute=False)
+    assert boom.status is None  # not computed; cheap default path
+
+
+def test_maybe_compute_status_computes_and_swallows_failure(context):
+    from nodes.graphql.types.node import _maybe_compute_status
+
+    boom = BoomNodeFactory.create(context=context)
+    _maybe_compute_status(boom, compute=True)  # must not raise
+    assert boom.status is NodeStatus.FAILED
+    assert len(boom.status_errors) == 1
+
+
+def test_maybe_compute_status_marks_clean_node_ok(context):
+    from nodes.graphql.types.node import _maybe_compute_status
+
+    leaf = _leaf(context)
+    _maybe_compute_status(leaf, compute=True)
+    assert leaf.status is NodeStatus.OK
+
+
 # --- tolerant mode ----------------------------------------------------------
 
 

--- a/nodes/tests/test_fault_tolerance.py
+++ b/nodes/tests/test_fault_tolerance.py
@@ -15,7 +15,7 @@ from nodes.edges import Edge
 from nodes.exceptions import NodeError
 from nodes.node import NodeErrorPhase, NodeStatus, NodeStatusError
 from nodes.simple import AdditiveNode, SimpleNode
-from nodes.tests.factories import NodeFactory
+from nodes.tests.factories import InstanceConfigFactory, InstanceFactory, NodeFactory
 
 if TYPE_CHECKING:
     from nodes.context import Context
@@ -146,6 +146,26 @@ def test_default_mode_unwired_additive_raises(context):
     context.finalize_nodes()
     with pytest.raises(NodeError):
         node.get_output_pl()
+
+
+# --- activation: enter_instance_context threads the flag onto the context ----
+
+
+def _instance_config():
+    instance = InstanceFactory.create()
+    return InstanceConfigFactory.create(identifier=instance.id, instance=instance)
+
+
+def test_enter_instance_context_sets_tolerant_flag():
+    ic = _instance_config()
+    with ic.enter_instance_context(tolerate_node_failures=True) as instance:
+        assert instance.context.tolerate_node_failures is True
+
+
+def test_enter_instance_context_defaults_to_fail_fast():
+    ic = _instance_config()
+    with ic.enter_instance_context() as instance:
+        assert instance.context.tolerate_node_failures is False
 
 
 # --- tolerant mode ----------------------------------------------------------

--- a/nodes/tests/test_model_editor.py
+++ b/nodes/tests/test_model_editor.py
@@ -280,6 +280,34 @@ def test_instance_admin_can_read_model_editor_fields(client, db_instance_config:
     assert node['editor']['spec']['outputPorts'][0]['id'] == str(_port_uuid('default'))
 
 
+NODE_STATUS_FIELDS = gql("""
+query NodeStatusFields($instanceId: ID!) {
+    modelInstance(instanceId: $instanceId) {
+        nodes {
+            identifier
+            editor {
+                status
+                errors {
+                    phase
+                    message
+                }
+            }
+        }
+    }
+}
+""")
+
+
+def test_node_editor_exposes_status_and_errors(gql_client: PathsTestClient, db_instance_config: InstanceConfig):
+    NodeConfigFactory.create(instance=db_instance_config, identifier='status_node', spec=_make_node_spec())
+    data = gql_client.query_data(NODE_STATUS_FIELDS, variables={'instanceId': str(db_instance_config.pk)})
+    nodes = {n['identifier']: n for n in data['modelInstance']['nodes']}
+    editor = nodes['status_node']['editor']
+    # Freshly loaded and not computed: status is null and no errors are recorded yet.
+    assert editor['status'] is None
+    assert editor['errors'] == []
+
+
 def test_create_node_formula(gql_client: PathsTestClient, db_instance_config: InstanceConfig):
     data = gql_client.query_data(
         CREATE_NODE,

--- a/paths/schema.py
+++ b/paths/schema.py
@@ -85,6 +85,15 @@ def instance_directive(
             ),
         ),
     ] = None,
+    tolerate_node_failures: Annotated[
+        bool,
+        sb.argument(
+            description=(
+                'Run the model in fault-tolerant mode: quarantine node failures and report them '
+                'as node status instead of aborting. For draft model editing; defaults to false.'
+            ),
+        ),
+    ] = False,
 ):
     pass
 
@@ -96,6 +105,14 @@ class InstanceContextInput:
     locale: str | None
     preview: PreviewMode | None = None
     version: UUID | None = None
+    tolerate_node_failures: bool = sb.field(
+        default=False,
+        description=(
+            'Run the model in fault-tolerant mode: quarantine node failures and report them as '
+            'node status (via the node editor) instead of aborting the whole computation. For '
+            'draft model editing; defaults to false. See docs/architecture/fault-tolerance.md.'
+        ),
+    )
 
 
 @sb.directive(

--- a/paths/schema_context.py
+++ b/paths/schema_context.py
@@ -47,6 +47,7 @@ class PathsGraphQLContext[InstanceType: Instance | None = Instance | None](Graph
     # (`preview_mode`).
     preview_mode: PreviewMode | None = None
     expected_version: UUID | None = None
+    tolerate_node_failures: bool = False
 
     def __post_init__(self):
         super().__post_init__()
@@ -139,7 +140,11 @@ class DetermineInstanceContextExtension(PathsSchemaExtension):
             ic = self.get_instance_by_hostname(qs, hostname, directive)
         else:
             raise GraphQLError('Invalid instance directive', directive)
-        self._apply_preview_and_version(arguments.get('preview'), arguments.get('version'))
+        self._apply_preview_and_version(
+            arguments.get('preview'),
+            arguments.get('version'),
+            arguments.get('tolerate_node_failures', False),
+        )
         return ic
 
     def process_context_directive(self, directive: DirectiveNode) -> tuple[InstanceConfig | None, str | None]:
@@ -167,25 +172,32 @@ class DetermineInstanceContextExtension(PathsSchemaExtension):
             locale = ic.primary_language
         elif locale not in ic.supported_languages:
             raise GraphQLError('unsupported language: %s. Did you run --update-instance?' % locale, directive)
-        self._apply_preview_and_version(ctx.get('preview'), ctx.get('version'))
+        self._apply_preview_and_version(
+            ctx.get('preview'),
+            ctx.get('version'),
+            ctx.get('tolerate_node_failures', False),
+        )
         return ic, locale
 
     def _apply_preview_and_version(
         self,
         preview: Any,
         version: Any,
+        tolerate_node_failures: bool = False,
     ) -> None:
         """
-        Stash the directive's ``preview`` / ``version`` args on the context.
+        Stash the directive's ``preview`` / ``version`` / fault-tolerance args on the context.
 
         ``preview`` reaches us as the ``PreviewMode`` enum instance (via
         ``get_argument_values``) or ``None``. ``version`` is a ``UUID`` or
         ``None``. Editing mutations later read ``expected_version`` to gate
-        the stale-check.
+        the stale-check. ``tolerate_node_failures`` opts into fault-tolerant
+        computation (see docs/architecture/fault-tolerance.md).
         """
         ctx = self.get_context()
         ctx.preview_mode = preview
         ctx.expected_version = version
+        ctx.tolerate_node_failures = bool(tolerate_node_failures)
 
     def process_instance_headers(self) -> InstanceConfig | None:
         headers = self.get_request_headers()
@@ -381,7 +393,9 @@ class ActivateInstanceContextExtension(PathsSchemaExtension):
                     perf.exec_node(GraphQLPerfNode('get instance "%s"' % ic.identifier)),
                     is_query_with_instance_context.set(True),
                 ):
-                    instance = stack.enter_context(ic.enter_instance_context(source=source))
+                    instance = stack.enter_context(
+                        ic.enter_instance_context(source=source, tolerate_node_failures=ctx.tolerate_node_failures),
+                    )
                     ctx.instance = instance
                 context = instance.context
                 stack.enter_context(instance.lock)


### PR DESCRIPTION
- **Add node-level fault tolerance for draft model editing**
- **Activate node fault tolerance via the context directive**
- **Add opt-in compute to node status/errors editor fields**
- **Add construction-time (tier-1) node fault tolerance**
