### PR TITLE
Add hide_scenario_editor and deprecate hide_node_details

### DIFF
--- a/configs/cork-nzc.yaml
+++ b/configs/cork-nzc.yaml
@@ -21,6 +21,7 @@ features:
   show_significant_digits: 4
   maximum_fraction_digits: 3
   hide_node_details: false
+  hide_scenario_editor: false
   show_refresh_prompt: false
   requires_authentication: true
   show_explanations: true

--- a/configs/dut-transport-nzc.yaml
+++ b/configs/dut-transport-nzc.yaml
@@ -24,6 +24,7 @@ features:
   show_significant_digits: 4
   maximum_fraction_digits: 2
   hide_node_details: false
+  hide_scenario_editor: false
 
 include:
 

--- a/configs/lappeenranta-nzc.yaml
+++ b/configs/lappeenranta-nzc.yaml
@@ -25,6 +25,7 @@ features:
   show_significant_digits: 4
   maximum_fraction_digits: 2
   hide_node_details: false
+  hide_scenario_editor: false
 
 include:
 - file: modules/health.yaml

--- a/configs/lucia.yaml
+++ b/configs/lucia.yaml
@@ -22,6 +22,7 @@ features:
   show_significant_digits: 6
   maximum_fraction_digits: 6
   hide_node_details: true
+  hide_scenario_editor: true
   show_refresh_prompt: true
   requires_authentication: true
   show_explanations: true

--- a/configs/nzc.yaml
+++ b/configs/nzc.yaml
@@ -26,6 +26,7 @@ features:
   show_significant_digits: 4
   maximum_fraction_digits: 0
   hide_node_details: true
+  hide_scenario_editor: true
   show_refresh_prompt: true
   requires_authentication: true
   show_explanations: true

--- a/nodes/defs/instance_defs.py
+++ b/nodes/defs/instance_defs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from kausal_common.i18n.pydantic import (
     I18nBaseModel,
@@ -109,8 +109,11 @@ class InstanceFeatures(BaseModel):
     maximum_fraction_digits: int | None = None
     """Maximum number of decimal places to display after the decimal point. None means no limit."""
 
-    hide_node_details: bool = False
-    """Whether to hide detailed node information in the UI."""
+    hide_node_details: bool = Field(default=False, deprecated=True)
+    """Deprecated: use hide_scenario_editor instead."""
+
+    hide_scenario_editor: bool = False
+    """Whether to hide the scenario editor (action/parameter controls) in the UI."""
 
     show_refresh_prompt: bool = False
     """Whether to show a prompt to refresh data when it might be outdated."""
@@ -129,6 +132,12 @@ class InstanceFeatures(BaseModel):
 
     show_category_warnings: bool = False
     """Whether to show category warnings in the node explanation."""
+
+    @model_validator(mode='after')
+    def _migrate_hide_node_details(self) -> InstanceFeatures:
+        if self.hide_node_details and not self.hide_scenario_editor:
+            self.hide_scenario_editor = True
+        return self
 
     model_config = ConfigDict(use_attribute_docstrings=True)
 

--- a/nodes/defs/instance_defs.py
+++ b/nodes/defs/instance_defs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from kausal_common.i18n.pydantic import (
     I18nBaseModel,
@@ -132,12 +132,6 @@ class InstanceFeatures(BaseModel):
 
     show_category_warnings: bool = False
     """Whether to show category warnings in the node explanation."""
-
-    @model_validator(mode='after')
-    def _migrate_hide_node_details(self) -> InstanceFeatures:
-        if self.hide_node_details and not self.hide_scenario_editor:
-            self.hide_scenario_editor = True
-        return self
 
     model_config = ConfigDict(use_attribute_docstrings=True)
 


### PR DESCRIPTION
## Description
The purpose of `hide_node_details` (used by NZP) has changed over time, this just updates the naming to reflect that meaning. Added a new field and deprecated the old one to avoid a breaking change.

## Screenshots/Videos (if applicable)
<img width="1514" height="366" alt="image" src="https://github.com/user-attachments/assets/cd455cf4-3dfe-4dd7-bce9-49da68b87bde" />
<img width="1515" height="340" alt="Screenshot 2026-06-17 at 13 19 45" src="https://github.com/user-attachments/assets/ee42dca7-46b4-4b48-b16e-141ce5db87d8" />

## Related issue
https://kausaltech.slack.com/archives/C0220JEEV1C/p1781687075637659

## Requirements, dependencies and related PRs
I'll open a separate UI PR, but have 

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [-] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
