### PR TITLE
Fix theme_identifier for framework-created instances

### DIFF
--- a/frameworks/models.py
+++ b/frameworks/models.py
@@ -38,8 +38,6 @@ from kausal_common.users import user_or_none
 from paths.types import CacheablePathsModel, PathsModel, PathsQuerySet
 from paths.utils import IdentifierField, UnitField
 
-from nodes.defs import InstanceModelSpec
-
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -771,7 +769,7 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
         target_year: int | None = None,
         user: UserOrAnon | None = None,
     ) -> FrameworkConfig:
-        from nodes.models import InstanceConfig
+        from nodes.models import InstanceConfig, make_minimal_instance_spec
         from orgs.models import Organization
 
         instance_name = '%s: %s' % (framework.name, org_name)
@@ -780,8 +778,10 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
         org = Organization.objects.get(name='NetZeroCities')
 
         uuid = uuid or uuid4()
-        # Identity metadata lives on the columns; the spec is computation-only.
-        spec = InstanceModelSpec()
+        # Identity metadata lives on the columns; the computation spec is
+        # populated from the framework YAML further below, once the framework
+        # link exists. It's left null here rather than set to an empty spec, so
+        # readers of the stored spec don't see a stale, theme-less default.
         ic = InstanceConfig.objects.create(
             name=instance_name,
             identifier=instance_identifier,
@@ -789,7 +789,7 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
             other_languages=[],
             organization=org,
             uuid=uuid,
-            spec=spec,
+            spec=None,
         )
 
         pp = cls.permission_policy()
@@ -821,6 +821,14 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
                 assert isinstance(alp, ActionListPage)
                 alp.show_in_footer = False
                 alp.save()
+
+            # Populate the computation spec from the framework YAML now that the
+            # framework config is linked. Without this, readers of the stored
+            # spec (e.g. `availableInstances` via `InstanceBasicConfiguration`)
+            # would see an empty spec and fall back to a theme-less default, even
+            # though the runtime instance carries the framework's theme_identifier.
+            ic.spec = make_minimal_instance_spec(ic.get_instance())
+            ic.save(update_fields=['spec'])
 
         return fc
 

--- a/frameworks/tests/test_mutations.py
+++ b/frameworks/tests/test_mutations.py
@@ -624,6 +624,43 @@ def test_create_nzc_framework_config_mutation_creates_instance_and_defaults(
     assert populated_framework_configs == [('nzc-created-city', 2020)]
 
 
+def test_create_instance_populates_spec_theme_from_framework_yaml() -> None:
+    """
+    The stored spec must carry the framework YAML's ``theme_identifier``.
+
+    ``availableInstances`` (via ``InstanceBasicConfiguration``) reads the theme
+    from the stored ``InstanceConfig.spec``, not from the runtime instance. If
+    ``create_instance`` leaves an empty spec, that query falls back to the
+    ``'default'`` theme even though the direct ``instance`` query (which reads
+    the runtime instance loaded from YAML) reports the correct one. This is a
+    regression test for that mismatch.
+    """
+    _create_net_zero_cities_organization()
+    # identifier='nzc' makes the YAML entrypoint resolve to configs/nzc.yaml,
+    # which declares `theme_identifier: eu-netzerocities`. A non-null
+    # public_base_fqdn gives the instance a site_url, so the node graph is
+    # synced and the spec gets populated from the loaded instance.
+    framework = FrameworkFactory.create(
+        identifier='nzc',
+        name='NetZeroCities',
+        public_base_fqdn='nzc.example.com',
+    )
+
+    fc = FrameworkConfig.create_instance(
+        framework=framework,
+        instance_identifier='nzc-theme-city',
+        org_name='NZC Theme City',
+        baseline_year=2020,
+    )
+
+    ic = fc.instance_config
+    assert ic.config_source == 'yaml'
+    assert ic.spec is not None
+    assert ic.spec.theme_identifier == 'eu-netzerocities'
+    # The lazy accessor that InstanceBasicConfiguration uses must agree.
+    assert ic.ensure_spec(save=False).theme_identifier == 'eu-netzerocities'
+
+
 # ---------------------------------------------------------------------------
 # registerUser
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
New framework-backed instances (e.g. created via NetZeroPlanner / `createFrameworkConfig`) showed the wrong theme: the default theme was used instead of the framework's. The `themeIdentifier` was correct when queried directly on an `instance`, but wrong when queried via `availableInstances`.

The two GraphQL fields resolve the theme from different sources:

- `InstanceType.themeIdentifier` reads the runtime `Instance`, which is loaded fresh from the framework YAML (e.g. configs/nzc.yaml) and so carries the correct `theme_identifier`.
- `InstanceBasicConfiguration.themeIdentifier` (used by `availableInstances`) reads `ensure_spec().theme_identifier` off the stored `InstanceConfig.spec`, falling back to 'default' when null.

`FrameworkConfig.create_instance` stored a hardcoded empty `InstanceModelSpec()`. That non-null-but-empty spec short-circuited the lazy YAML reload in `ensure_spec` (`if self.spec is not None: return`), so the stored theme stayed None and `availableInstances` returned 'default'.

Create the `InstanceConfig` with `spec=None`, then populate the spec from the loaded framework instance via `make_minimal_instance_spec` once the framework link exists and nodes are synced. This carries the YAML-derived `theme_identifier` (plus years and features) into the stored spec, so both query paths agree.

Note: existing affected instances still need a one-time backfill (clear `spec` and re-save so `ensure_spec` reloads it from YAML).

## Related issue
[Slack thread](https://kausaltech.slack.com/archives/C04RYGKBZJR/p1782475595435209)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Manually tested locally** (functionality verified)