### PR TITLE
load_dvc_dataset: diagnose first, then refresh in place

### DIFF
--- a/docs/trailhead/tools.md
+++ b/docs/trailhead/tools.md
@@ -53,6 +53,55 @@ python tools/debug_instance.py -i espoo --source db --node net_emissions
 ```
 
 
+## load_dvc_dataset
+
+Imports a DVC dataset into the DB as a `Dataset` row. Two phases:
+diagnose, then apply.
+
+```bash
+# Phase 1 -- what exists, and what would change? Writes nothing.
+python manage.py load_dvc_dataset espoo espoo/buildings --plan
+
+# Phase 2 -- apply. Existing rows are refreshed in place (same pk and UUID),
+# so DatasetPort / NodeDataset / revision-pin references stay valid.
+python manage.py load_dvc_dataset espoo espoo/buildings --force
+```
+
+The plan reports the row's pk/UUID, the commit its data came from versus the
+one about to be imported, the data-point count on both sides, and which
+metrics are kept, added or dropped.
+
+### Which commit gets imported
+
+Every run prints the repository and commit it is reading, and where that pin
+came from. `--repo-from` chooses:
+
+- `auto` (default) — the instance's declared `config_source`. For a
+  DB-sourced instance that is the DB spec's pin, which lags the YAML until
+  `sync_instance_to_db` runs.
+- `yaml` — the pin in `configs/<instance>.yaml`.
+- `db` — the pin in the stored `InstanceConfig.spec`.
+
+When the two pins disagree the command warns and names the other one. This
+matters because importing from the wrong commit is otherwise invisible: it
+surfaces much later as `No metric <column> in dataset <id>` from
+`sync_instance_to_db`, which reads the YAML regardless of `config_source`.
+
+### Things that will stop a run
+
+- **A dropped metric that dataset ports still bind.** Refused up front, with
+  the port count, rather than leaving a node bound to input that no longer
+  arrives. Update the model binding or keep the column in the data.
+- **`--all` with `use_datasets_from_db`.** Any identifier that already has a
+  DB row loads as a `DBDataset`, so `ctx.get_all_dvc_dataset_ids()` is empty
+  and `--all` has nothing to do. Name the datasets explicitly.
+
+`--recreate` restores the old delete-and-rebuild behaviour. It mints a new
+UUID, which orphans the dataset references held by published instance
+revisions, and it fails outright when anything references the row under
+`PROTECT` — use it only when you want a genuinely fresh row.
+
+
 ## sync_instance_to_db
 
 Exports runtime node specs from YAML-loaded instances into the DB.

--- a/nodes/management/commands/load_dvc_dataset.py
+++ b/nodes/management/commands/load_dvc_dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import date
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -35,7 +36,10 @@ from nodes.datasets import JSONDataset
 from nodes.models import InstanceConfig
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from nodes.context import Context
+    from nodes.defs.instance_defs import DatasetRepoSpec
     from nodes.dimensions import Dimension as DimensionSpec, DimensionCategory as DimensionCategorySpec
     from nodes.units import Unit
 
@@ -57,6 +61,181 @@ COMMENT_SEPARATOR = ' ;; '
 # through to DVC as literal per-row data (excluded from index_columns there) rather than
 # being dimensions or metrics -- read back here into DataSource/DataPointComment links.
 RESERVED_ROW_COLUMNS = {'source', 'comment', 'description'}
+
+
+@dataclass
+class RepoProvenance:
+    """Which DVC commit this run will read from, and which one the other config source names."""
+
+    used_source: str
+    """'yaml' or 'db' -- where the effective pin came from."""
+
+    yaml_commit: str | None
+    db_commit: str | None
+    spec: DatasetRepoSpec | None
+
+    @property
+    def sources_disagree(self) -> bool:
+        return self.yaml_commit is not None and self.db_commit is not None and self.yaml_commit != self.db_commit
+
+
+def _yaml_repo_spec(ic: InstanceConfig) -> DatasetRepoSpec | None:
+    """Read ``dataset_repo`` straight from the instance's YAML entrypoint, without loading the model."""
+    from nodes.defs.instance_defs import DatasetRepoSpec
+    from nodes.instance_loader import InstanceYAMLConfig
+
+    path: Path | None = ic.get_yaml_config_entrypoint()
+    if path is None:
+        return None
+    yaml_conf = InstanceYAMLConfig.load_for_entrypoint(path)
+    repo = (yaml_conf.data or {}).get('dataset_repo')
+    if not repo:
+        return None
+    return DatasetRepoSpec.model_validate(repo)
+
+
+def resolve_repo_provenance(ic: InstanceConfig, ctx: Context, repo_from: str) -> RepoProvenance:
+    """
+    Decide which dataset-repo pin to import from, and record the one we are not using.
+
+    ``ctx`` already carries the pin belonging to the instance's declared ``config_source``
+    (YAML file or DB spec). The point of resolving both is that importing data from a
+    different commit than the model expects is silent: it surfaces later, and far away,
+    as a missing metric. ``repo_from='auto'`` keeps the declared source -- which side is
+    authoritative changes as the model editor takes over -- but a disagreement is always
+    reported.
+    """
+    ctx_spec: DatasetRepoSpec | None = ctx.dataset_repo_spec
+    declared_is_yaml = ic.config_source == 'yaml'
+
+    yaml_spec = ctx_spec if declared_is_yaml else _yaml_repo_spec(ic)
+    db_spec = ctx_spec if not declared_is_yaml else (ic.spec.dataset_repo if ic.spec is not None else None)
+
+    if repo_from == 'yaml':
+        spec, used = yaml_spec, 'yaml'
+    elif repo_from == 'db':
+        spec, used = db_spec, 'db'
+    else:
+        spec, used = ctx_spec, ('yaml' if declared_is_yaml else 'db')
+
+    return RepoProvenance(
+        used_source=used,
+        yaml_commit=yaml_spec.commit if yaml_spec is not None else None,
+        db_commit=db_spec.commit if db_spec is not None else None,
+        spec=spec,
+    )
+
+
+def apply_repo_provenance(ctx: Context, provenance: RepoProvenance) -> None:
+    """Point ``ctx`` at the resolved pin, dropping the cached repo if it was already built."""
+    if provenance.spec is None or provenance.spec is ctx.dataset_repo_spec:
+        return
+    ctx.dataset_repo_spec = provenance.spec
+    ctx.__dict__.pop('dataset_repo', None)
+
+
+@dataclass
+class DatasetPlan:
+    """What a sync would do to one dataset, computed before anything is written."""
+
+    ds_id: str
+    incoming_commit: str | None
+    existing_pk: int | None = None
+    existing_uuid: str | None = None
+    current_commit: str | None = None
+    current_data_points: int = 0
+    incoming_data_points: int = 0
+    kept_metrics: list[str] = field(default_factory=list)
+    added_metrics: list[str] = field(default_factory=list)
+    dropped_metrics: list[tuple[str, int]] = field(default_factory=list)
+    """(metric name, number of dataset ports binding it) for columns no longer in the DVC data."""
+
+    is_placeholder: bool = False
+    schema_shared_with: int = 0
+
+    @property
+    def is_new(self) -> bool:
+        return self.existing_pk is None
+
+    @property
+    def blockers(self) -> list[str]:
+        """
+        Reasons this sync must not proceed.
+
+        A metric that the model still binds cannot lose its column: the node would
+        keep a port pointing at data that no longer arrives. Better to say so here,
+        naming the ports, than to let it surface later as a missing metric during
+        ``sync_instance_to_db`` -- or not at all, as silently empty input.
+        """
+        return [
+            f'metric {name!r} would be dropped but {n} dataset port(s) still bind it' for name, n in self.dropped_metrics if n
+        ]
+
+
+def build_dataset_plan(
+    ds_id: str,
+    dataset: Dataset | None,
+    incoming_metric_cols: list[str],
+    incoming_data_points: int,
+    incoming_commit: str | None,
+) -> DatasetPlan:
+    """Diff the DB state of one dataset against the DVC data about to be imported."""
+    from nodes.models import DatasetPort
+
+    plan = DatasetPlan(
+        ds_id=ds_id,
+        incoming_commit=incoming_commit,
+        incoming_data_points=incoming_data_points,
+        added_metrics=list(incoming_metric_cols),
+    )
+    if dataset is None:
+        return plan
+
+    plan.existing_pk = dataset.pk
+    plan.existing_uuid = str(dataset.uuid)
+    plan.current_commit = (dataset.external_ref or {}).get('commit')
+    plan.current_data_points = dataset.data_points.count()
+    plan.is_placeholder = dataset.is_external_placeholder
+    schema = dataset.schema
+    if schema is None:
+        return plan
+
+    plan.schema_shared_with = schema.datasets.count()
+    existing = {m.name: m for m in schema.metrics.all() if m.name}
+    incoming = set(incoming_metric_cols)
+    plan.kept_metrics = sorted(name for name in existing if name in incoming)
+    plan.added_metrics = sorted(name for name in incoming if name not in existing)
+    plan.dropped_metrics = sorted(
+        (name, DatasetPort.objects.filter(metric=metric).count()) for name, metric in existing.items() if name not in incoming
+    )
+    return plan
+
+
+def print_dataset_plan(plan: DatasetPlan) -> None:
+    """Render one dataset's plan; the same output precedes an apply run and stands alone under --plan."""
+    print(f'[bold]{plan.ds_id}[/bold]')
+    if plan.is_new:
+        print('  row          [green]new[/green]')
+    else:
+        kind = ' (external placeholder)' if plan.is_placeholder else ''
+        print(f'  row          pk={plan.existing_pk} uuid={plan.existing_uuid}{kind}')
+    commit_from = plan.current_commit or 'unrecorded'
+    if plan.is_new:
+        print(f'  commit       {plan.incoming_commit}')
+    elif commit_from == plan.incoming_commit:
+        print(f'  commit       {commit_from} [dim](unchanged)[/dim]')
+    else:
+        print(f'  commit       {commit_from} [yellow]->[/yellow] {plan.incoming_commit}')
+    print(f'  data points  {plan.current_data_points} -> {plan.incoming_data_points}')
+    if plan.kept_metrics:
+        print(f'  metrics kept {", ".join(plan.kept_metrics)}')
+    if plan.added_metrics:
+        print(f'  metrics [green]add[/green]  {", ".join(plan.added_metrics)}')
+    for name, port_count in plan.dropped_metrics:
+        suffix = f' [red](bound by {port_count} dataset port(s))[/red]' if port_count else ''
+        print(f'  metrics [yellow]drop[/yellow] {name}{suffix}')
+    for problem in plan.blockers:
+        print(f'  [red]blocker[/red]      {problem}')
 
 
 def _translated_metadata(values: dict[str, str], default_language: str) -> TranslatedString:
@@ -130,10 +309,33 @@ class Command(BaseCommand):
                 'DIMENSION_ID. Can be used multiple times.'
             ),
         )
-        parser.add_argument('--force', action='store_true')
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            help='Replace the data of datasets that already exist in the DB (the row itself is kept)',
+        )
+        parser.add_argument(
+            '--plan',
+            action='store_true',
+            help='Diagnose only: report what exists and what this run would change, without writing anything',
+        )
+        parser.add_argument(
+            '--repo-from',
+            choices=['auto', 'yaml', 'db'],
+            default='auto',
+            help=(
+                "Which dataset-repo pin to import from: the instance's declared config source (auto, the default), "
+                'the YAML file, or the DB spec.'
+            ),
+        )
+        parser.add_argument(
+            '--recreate',
+            action='store_true',
+            help='With --force, delete and recreate the dataset row instead of refreshing it in place (mints a new UUID)',
+        )
 
     @transaction.atomic
-    def sync_dataset(  # noqa: C901, PLR0915
+    def sync_dataset(  # noqa: C901, PLR0912, PLR0915
         self,
         instance_config: InstanceConfig,
         ctx: Context,
@@ -141,9 +343,14 @@ class Command(BaseCommand):
         force: bool = False,
         metadata_only: bool = False,
         create_dimensions_from_columns: dict[str, str] | None = None,
+        plan_only: bool = False,
+        recreate: bool = False,
     ):
         create_dimensions_from_columns = create_dimensions_from_columns or {}
         if metadata_only:
+            if plan_only:
+                print(f'{ds_id}: would sync placeholder metadata only')
+                return
             sync_dataset_placeholder(instance_config, ctx, ds_id, force=force, reporter=print)
             return
 
@@ -173,6 +380,24 @@ class Command(BaseCommand):
             raise RuntimeError(f"Multiple datasets with identifier '{identifier}' exist for instance '{instance_config}'.")
         if datasets:
             dataset = datasets[0]
+
+        plan = build_dataset_plan(
+            ds_id=ds_id,
+            dataset=dataset,
+            incoming_metric_cols=list(df_metadata.metric_cols),
+            incoming_data_points=sum(df[col].drop_nulls().len() for col in df_metadata.metric_cols),
+            incoming_commit=(make_external_dataset_ref(ctx, ds_id) or {}).get('commit'),
+        )
+        print_dataset_plan(plan)
+        if plan_only:
+            return
+        if plan.blockers:
+            raise CommandError(
+                f'{ds_id}: refusing to sync -- ' + '; '.join(plan.blockers) + '. Update the model bindings first, '
+                'or keep the column in the DVC data.'
+            )
+
+        if dataset is not None:
             if dataset.is_external_placeholder:
                 print(f"Dataset '{dataset}' with identifier '{identifier}' is an external placeholder. Replacing.")
                 dataset.is_external_placeholder = False
@@ -182,7 +407,11 @@ class Command(BaseCommand):
                 dataset.save(update_fields=['is_external_placeholder', 'scope_content_type', 'scope_id', 'external_ref'])
                 schema = dataset.schema
                 assert schema is not None
-            elif force:
+            elif not force:
+                print(f"Dataset '{dataset}' with identifier '{identifier}' exists for instance '{instance_config}'. Aborting.")
+                print('Pass --force to replace its data.')
+                return
+            elif recreate:
                 schema = dataset.schema
                 assert schema is not None
                 if schema.datasets.count() > 1:
@@ -192,9 +421,19 @@ class Command(BaseCommand):
                 dataset.delete()
                 print(f"Deleting dataset schema '{schema}'")
                 schema.delete()
+                # Both objects are now unsaved (the collector nulls their pks), so drop the
+                # references: the code below recreates them only when they are None.
+                dataset = None
+                schema = None
             else:
-                print(f"Dataset '{dataset}' with identifier '{identifier}' exists for instance '{instance_config}'. Aborting.")
-                return
+                schema = self.refresh_dataset_in_place(
+                    dataset=dataset,
+                    ctx=ctx,
+                    ds_id=ds_id,
+                    plan=plan,
+                    dvc_metadata=dvc_metadata,
+                    default_language=ctx.instance.default_language,
+                )
 
         if schema is None:
             schema = self.create_dataset_schema(
@@ -225,6 +464,15 @@ class Command(BaseCommand):
             for col in df_metadata.metric_cols
             if col not in metrics
         })
+        # A reused metric keeps its row, so a unit change in the DVC data would otherwise be
+        # silently ignored -- the values would land under the old unit.
+        for col in df_metadata.metric_cols:
+            metric = metrics[col]
+            incoming_unit = str(df_metadata.units[col])
+            if metric.pk is not None and metric.unit != incoming_unit:
+                print(f"Metric '{col}': unit {metric.unit} -> {incoming_unit}")
+                metric.unit = incoming_unit
+                metric.save(update_fields=['unit'])
 
         df, column_dimensions = self.sync_dimensions(
             schema=schema,
@@ -271,6 +519,52 @@ class Command(BaseCommand):
             scope_content_type=ContentType.objects.get_for_model(instance_config),
             scope_id=instance_config.pk,
         )
+        return schema
+
+    def refresh_dataset_in_place(
+        self,
+        dataset: Dataset,
+        ctx: Context,
+        ds_id: str,
+        plan: DatasetPlan,
+        dvc_metadata: dict,
+        default_language: str,
+    ) -> DatasetSchema:
+        """
+        Replace a dataset's contents while keeping the row itself.
+
+        Deleting and recreating the row is the older strategy, and it is destructive in
+        ways that are easy to miss: ``DatasetPort``, ``NodeDataset`` and
+        ``InstanceRevisionDatasetPin`` all reference the row under ``PROTECT``, and the
+        new row gets a fresh UUID, which orphans the dataset references stored in
+        published instance revisions. Keeping the pk and UUID leaves every one of those
+        intact; only the data underneath changes.
+        """
+        schema = dataset.schema
+        assert schema is not None
+
+        deleted, _ = dataset.data_points.all().delete()
+        print(f'Deleted {deleted} row(s) of existing data')
+
+        for name, port_count in plan.dropped_metrics:
+            assert not port_count, 'bound metrics are refused before we get here'
+            if plan.schema_shared_with > 1:
+                print(f"Keeping stale metric '{name}': the schema is shared with other datasets")
+                continue
+            DatasetMetric.objects.filter(schema=schema, name=name).delete()
+            print(f"Deleted stale metric '{name}' (no longer in the DVC data)")
+
+        # Restamp provenance, so the row records the commit its data actually came from.
+        dataset.external_ref = make_external_dataset_ref(ctx, ds_id)
+        dataset.save(update_fields=['external_ref'])
+
+        name_i18n = dvc_metadata.get('name')
+        if name_i18n is not None:
+            _translated_metadata(name_i18n, default_language).set_modeltrans_field(schema, 'name', default_language)
+        description_i18n = dvc_metadata.get('description')
+        if description_i18n:
+            schema.description = description_i18n.get(default_language) or next(iter(description_i18n.values()))
+        schema.save()
         return schema
 
     def get_or_create_data_sources(
@@ -598,20 +892,52 @@ class Command(BaseCommand):
         print(f"Created dimension category '{cat}'")
         return cat
 
-    def handle(self, *args, **options):
+    def report_provenance(self, ic: InstanceConfig, provenance: RepoProvenance) -> None:
+        """Say which commit the data will come from, and flag a disagreement between the two sources."""
+        spec = provenance.spec
+        if spec is None:
+            print('[yellow]No dataset repository configured for this instance[/yellow]')
+            return
+        print(f'Instance   {ic.identifier} (config_source={ic.config_source})')
+        print(f'Repository {spec.url}')
+        print(f'Commit     {spec.commit} [dim](from {provenance.used_source})[/dim]')
+        if provenance.sources_disagree:
+            other = 'db' if provenance.used_source == 'yaml' else 'yaml'
+            other_commit = provenance.db_commit if other == 'db' else provenance.yaml_commit
+            print(
+                f'[yellow]Warning:[/yellow] the {other} config pins a different commit ({other_commit}). '
+                f'Data will be imported from the {provenance.used_source} pin above; '
+                f'pass --repo-from {other} to use the other one.'
+            )
+
+    def handle(self, *args, **options):  # noqa: C901, PLR0912
         instance_id = options['instance'][0]
         ic = InstanceConfig.objects.get(identifier=instance_id)
         ctx = ic.get_instance().context
+
+        provenance = resolve_repo_provenance(ic, ctx, options['repo_from'])
+        apply_repo_provenance(ctx, provenance)
+        self.report_provenance(ic, provenance)
+
         if not options['datasets']:
+            dvc_dataset_ids = sorted(ctx.get_all_dvc_dataset_ids())
+            if not dvc_dataset_ids:
+                # With `use_datasets_from_db`, any identifier that already has a DB row loads as a
+                # DBDataset, so it never appears here. An empty list then means "everything is
+                # already imported", not "this instance has no datasets" -- say so, rather than
+                # silently doing nothing.
+                print(
+                    '[yellow]No DVC-backed datasets found for this instance.[/yellow] '
+                    'If it uses datasets from the DB, every identifier already has a row; '
+                    'name the datasets explicitly to re-import them.'
+                )
+                return
             if not options['all']:
                 print('Available datasets:')
-                dvc_dataset_ids = sorted(ctx.get_all_dvc_dataset_ids())
                 for ds_id in dvc_dataset_ids:
                     print(ds_id)
-                exit()
-            else:
-                dvc_dataset_ids = sorted(ctx.get_all_dvc_dataset_ids())
-                ds_ids = dvc_dataset_ids
+                return
+            ds_ids = dvc_dataset_ids
         else:
             ds_ids = options['datasets']
 
@@ -636,6 +962,7 @@ class Command(BaseCommand):
 
             ds_ids = filtered_ds_ids
 
+        plan_only = options['plan']
         for ds_id in ds_ids:
             with transaction.atomic():
                 self.sync_dataset(
@@ -645,4 +972,12 @@ class Command(BaseCommand):
                     force=options['force'],
                     metadata_only=options['metadata_only'],
                     create_dimensions_from_columns=create_dimensions_from_columns,
+                    plan_only=plan_only,
+                    recreate=options['recreate'],
                 )
+                if plan_only:
+                    # Nothing was written, but a plan run must not leave anything behind even
+                    # if a code path below the diff decided to create something.
+                    transaction.set_rollback(True)
+        if plan_only:
+            print('\n[bold]--plan: nothing was written.[/bold] Re-run with --force to apply.')

--- a/nodes/tests/test_load_dvc_dataset_refresh.py
+++ b/nodes/tests/test_load_dvc_dataset_refresh.py
@@ -1,0 +1,185 @@
+"""Tests for re-importing a dataset that already exists in the DB (`load_dvc_dataset --force`)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID
+
+import polars as pl
+import pytest
+
+from kausal_common.datasets.models import DataPoint, Dataset, DatasetMetric
+
+from nodes.management.commands.load_dvc_dataset import Command, build_dataset_plan
+from nodes.models import DatasetPort, NodeConfig
+from nodes.tests.factories import InstanceConfigFactory, NodeConfigFactory
+
+pytestmark = pytest.mark.django_db
+
+DS_ID = 'test/refresh'
+
+
+def make_context(df: pl.DataFrame, units: dict[str, str], commit: str | None = None) -> Any:
+    """Build a stand-in for the runtime Context, carrying just what sync_dataset reads."""
+    dvc_dataset = SimpleNamespace(
+        df=df,
+        units=units,
+        index_columns=['Year'],
+        metadata={'name': {'en': 'Refreshable dataset'}, 'metrics': [{'column_id': col} for col in units]},
+    )
+    repo_spec = SimpleNamespace(url='https://example.com/dvc.git', commit=commit, dvc_remote=None) if commit else None
+    return cast(
+        'Any',
+        SimpleNamespace(
+            dataset_repo_spec=repo_spec,
+            dimensions={},
+            instance=SimpleNamespace(default_language='en'),
+            load_dvc_dataset=lambda _dataset_id: dvc_dataset,
+        ),
+    )
+
+
+def test_force_reimport_replaces_data_in_place():
+    """The row survives a --force re-import: same pk and UUID, new data, restamped commit."""
+    ic = InstanceConfigFactory.create(name='refresh-instance', config_source='database')
+
+    first = make_context(pl.DataFrame({'Year': [2020, 2021], 'value': [1.0, 2.0]}), {'value': 'kt'}, commit='aaa111')
+    Command().sync_dataset(ic, first, DS_ID)
+
+    dataset = Dataset.objects.get(identifier=DS_ID)
+    original_pk, original_uuid = dataset.pk, dataset.uuid
+    assert DataPoint.objects.filter(dataset=dataset).count() == 2
+
+    second = make_context(
+        pl.DataFrame({'Year': [2020, 2021, 2022], 'value': [10.0, 20.0, 30.0]}), {'value': 'kt'}, commit='bbb222'
+    )
+    Command().sync_dataset(ic, second, DS_ID, force=True)
+
+    dataset.refresh_from_db()
+    assert dataset.pk == original_pk, 'the row must be reused, not recreated'
+    assert dataset.uuid == original_uuid, 'a new UUID would orphan references in published revisions'
+    assert (dataset.external_ref or {})['commit'] == 'bbb222', 'provenance must record the commit the data came from'
+
+    values = sorted(float(dp.value) for dp in DataPoint.objects.filter(dataset=dataset) if dp.value is not None)
+    assert values == [10.0, 20.0, 30.0], 'old data points must be gone, not merged with the new ones'
+
+
+def test_force_reimport_survives_a_protected_reference():
+    """A DatasetPort binding the dataset used to make --force fail with ProtectedError."""
+    ic = InstanceConfigFactory.create(name='refresh-ported', config_source='database')
+    ctx = make_context(pl.DataFrame({'Year': [2020], 'value': [1.0]}), {'value': 'kt'}, commit='aaa111')
+    Command().sync_dataset(ic, ctx, DS_ID)
+
+    dataset = Dataset.objects.get(identifier=DS_ID)
+    metric = DatasetMetric.objects.get(schema=dataset.schema, name='value')
+    node: NodeConfig = NodeConfigFactory.create(instance=ic)
+    port = DatasetPort.objects.create(
+        instance=ic,
+        node=node,
+        port_id=UUID('11111111-1111-1111-1111-111111111111'),
+        dataset=dataset,
+        metric=metric,
+    )
+
+    newer = make_context(pl.DataFrame({'Year': [2020, 2021], 'value': [5.0, 6.0]}), {'value': 'kt'}, commit='bbb222')
+    Command().sync_dataset(ic, newer, DS_ID, force=True)
+
+    port.refresh_from_db()
+    assert port.dataset_id == dataset.pk, 'the binding must still resolve after the refresh'
+    assert DataPoint.objects.filter(dataset=dataset).count() == 2
+
+
+def test_recreate_builds_a_fresh_row():
+    """--recreate keeps the old delete-and-rebuild strategy; it used to leave both objects unsaved."""
+    ic = InstanceConfigFactory.create(name='refresh-recreate', config_source='database')
+    Command().sync_dataset(ic, make_context(pl.DataFrame({'Year': [2020], 'value': [1.0]}), {'value': 'kt'}), DS_ID)
+    original_pk = Dataset.objects.get(identifier=DS_ID).pk
+
+    newer = make_context(pl.DataFrame({'Year': [2020, 2021], 'value': [7.0, 8.0]}), {'value': 'kt'})
+    Command().sync_dataset(ic, newer, DS_ID, force=True, recreate=True)
+
+    dataset = Dataset.objects.get(identifier=DS_ID)
+    assert dataset.pk != original_pk
+    assert DataPoint.objects.filter(dataset=dataset).count() == 2
+
+
+def test_force_reimport_updates_a_changed_unit():
+    ic = InstanceConfigFactory.create(name='refresh-units', config_source='database')
+    Command().sync_dataset(ic, make_context(pl.DataFrame({'Year': [2020], 'value': [1.0]}), {'value': 'kt'}), DS_ID)
+
+    Command().sync_dataset(ic, make_context(pl.DataFrame({'Year': [2020], 'value': [1.0]}), {'value': 'Mt'}), DS_ID, force=True)
+
+    dataset = Dataset.objects.get(identifier=DS_ID)
+    assert DatasetMetric.objects.get(schema=dataset.schema, name='value').unit == 'Mt'
+
+
+def test_plan_reports_the_diff_without_writing():
+    ic = InstanceConfigFactory.create(name='refresh-plan', config_source='database')
+    ctx = make_context(pl.DataFrame({'Year': [2020], 'value': [1.0]}), {'value': 'kt'}, commit='aaa111')
+    Command().sync_dataset(ic, ctx, DS_ID)
+    dataset = Dataset.objects.get(identifier=DS_ID)
+
+    newer = make_context(
+        pl.DataFrame({'Year': [2020, 2021], 'value': [1.0, 2.0], 'extra': [3.0, 4.0]}),
+        {'value': 'kt', 'extra': 'kt'},
+        commit='bbb222',
+    )
+    Command().sync_dataset(ic, newer, DS_ID, force=True, plan_only=True)
+
+    assert DataPoint.objects.filter(dataset=dataset).count() == 1, '--plan must not touch the data'
+    assert not DatasetMetric.objects.filter(schema=dataset.schema, name='extra').exists()
+
+
+def test_provenance_reports_disagreeing_pins(monkeypatch: pytest.MonkeyPatch):
+    """Importing from a different commit than the model expects must never be silent."""
+    from nodes.defs.instance_defs import DatasetRepoSpec
+    from nodes.management.commands import load_dvc_dataset as mod
+
+    url = 'https://example.com/dvc.git'
+    ic = InstanceConfigFactory.create(name='prov-mismatch', config_source='database')
+    db_spec = DatasetRepoSpec(url=url, commit='db00000')
+    assert ic.spec is not None
+    ic.spec.dataset_repo = db_spec
+    ctx = cast('Any', SimpleNamespace(dataset_repo_spec=db_spec))
+    monkeypatch.setattr(mod, '_yaml_repo_spec', lambda _ic: DatasetRepoSpec(url=url, commit='yaml111'))
+
+    auto = mod.resolve_repo_provenance(ic, ctx, 'auto')
+    assert auto.used_source == 'db', "auto follows the instance's declared config source"
+    assert auto.spec is not None
+    assert auto.spec.commit == 'db00000'
+    assert auto.sources_disagree
+
+    override = mod.resolve_repo_provenance(ic, ctx, 'yaml')
+    assert override.used_source == 'yaml'
+    assert override.spec is not None
+    assert override.spec.commit == 'yaml111'
+
+
+def test_plan_flags_a_dropped_metric_that_ports_still_bind():
+    """The diagnosis names the blocker up front instead of leaving it for sync_instance_to_db."""
+    ic = InstanceConfigFactory.create(name='refresh-blocked', config_source='database')
+    Command().sync_dataset(
+        ic, make_context(pl.DataFrame({'Year': [2020], 'old_col': [1.0]}), {'old_col': 'kt'}, commit='aaa111'), DS_ID
+    )
+    dataset = Dataset.objects.get(identifier=DS_ID)
+    metric = DatasetMetric.objects.get(schema=dataset.schema, name='old_col')
+    DatasetPort.objects.create(
+        instance=ic,
+        node=NodeConfigFactory.create(instance=ic),
+        port_id=UUID('22222222-2222-2222-2222-222222222222'),
+        dataset=dataset,
+        metric=metric,
+    )
+
+    plan = build_dataset_plan(
+        ds_id=DS_ID,
+        dataset=dataset,
+        incoming_metric_cols=['new_col'],
+        incoming_data_points=1,
+        incoming_commit='bbb222',
+    )
+
+    assert plan.dropped_metrics == [('old_col', 1)]
+    assert plan.added_metrics == ['new_col']
+    assert plan.blockers, 'dropping a bound metric must be reported as a blocker'


### PR DESCRIPTION
Re-importing a dataset that already existed was broken in three ways, all of which showed up while updating the Longmont datasets on production.

`--force` raised `ValueError: Model instances passed to related filters must be saved`. Since a910cd46 the force branch deleted the dataset and its schema but left both locals bound to the deleted objects; Django's collector nulls their pks, so the `is None` guards below skipped recreation and the code carried on with unsaved instances. Broken for every non-placeholder dataset since then -- placeholders take the other branch and never delete.

Deleting the row was the wrong strategy anyway. `DatasetPort`, `NodeDataset` and `InstanceRevisionDatasetPin` all reference it under PROTECT, so a plain update had to be preceded by hand-deleting rows in a shell, and the replacement got a fresh UUID, orphaning the dataset references held by published revisions. Existing rows are now refreshed in place: same pk, same UUID, data replaced, `external_ref` restamped with the commit the data actually came from. Metric units are reconciled too, which a reused metric row would otherwise ignore. `--recreate` keeps the old behaviour for when a genuinely new row is wanted.

Both of those were only findable by reading tracebacks, so the command now has a diagnosis phase. `--plan` reports, per dataset, the row's identity, the commit it holds versus the one about to be imported, data-point counts on both sides, and which metrics are kept, added or dropped -- and refuses to drop a metric that dataset ports still bind, instead of letting that surface later as `No metric X in dataset Y` from sync_instance_to_db.

The commit actually used is now always printed. `load_dvc_dataset` resolves the DVC pin through the instance's declared config source, while sync_instance_to_db always parses the YAML, so a DB-sourced instance with a stale spec silently imports old data. `--repo-from {auto,yaml,db}` picks the pin explicitly and a disagreement between the two is reported rather than assumed away. Which side is authoritative will change as the model editor takes over, so neither is hardcoded.

Finally, `--all` said nothing when it found nothing: with `use_datasets_from_db` every identifier that already has a DB row loads as a DBDataset, so `get_all_dvc_dataset_ids()` is empty and the run was a silent no-op.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- ✅ **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- ✅ **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

-----

# Planned next steps

## 1. Register `DatasetPort` in the Wagtail reference index

**The symptom.** The Wagtail admin reported a dataset as "referenced 0 times" and
then returned HTTP 500 on delete. Both statements came from the same gap: the
usage view counts only what is registered with `ReferenceIndex`, and the 500 was an
unhandled `ProtectedError`.

**Why it is half-wired.** `NodeDataset` *is* registered, with signal handlers and a
custom URL finder (`nodes/wagtail_hooks.py:16-48`). `DatasetPort` — added later for
the model editor, and now the referrer that matters — is not registered anywhere.
The dataset in question had 10 `DatasetPort` rows and 0 `NodeDataset` rows, so the
count of 0 was accurate about the wrong table.

**Proposal.** Register `DatasetPort` the same way `NodeDataset` already is:
`ReferenceIndex.register_model`, `post_save`/`post_delete` receivers, and an
`AdminURLFinder` returning the owning node's edit URL. Then make the delete view
catch `ProtectedError` and render the referrers instead of 500ing — worth doing
regardless of the index, since `InstanceRevisionDatasetPin` also protects the row
and will never be a "reference" in the editorial sense.

**To settle:**

1. Should the admin offer to delete a dataset that ports still bind at all, or
   should deletion be refused with an explanation and left to the model editor?
   Deleting one silently unbinds node inputs.
2. Does the reference index need backfilling for existing `DatasetPort` rows
   (`wagtail_update_index`), or is registration enough going forward?

**Effort:** small — roughly the existing 30 lines of `nodes/wagtail_hooks.py`
adapted, plus the delete-view error handling.

---

## 2. Retire `NodeDataset` in favour of `DatasetPort`

**The problem.** Two tables now track the same node→dataset relationship, both
with `on_delete=PROTECT`:

- `NodeDataset` (`nodes/models.py:2189`), the April-2025 M2M through-model
- `DatasetPort` (`nodes/models.py:2262`), the 2026 model-editor version, which
  additionally carries the port, the metric, the binding spec and the index

Every dataset cleanup has to know about both, and they can disagree. During the
Longmont update, clearing the ports was not enough: the delete then failed a second
time on `NodeDataset`.

**Mechanically it looks cheap.** The only reader of the M2M in the repo is
`NodeConfig.update_relations_from_node()` (`nodes/models.py:2072-2089`) — which is
also its only writer — plus the Wagtail wiring in item 8. No GraphQL type, admin
view or framework code reads it.

**Proposal.** Move the reference-index registration to `DatasetPort` (item 8), drop
`NodeDataset` and the `NodeConfig.datasets` M2M, and delete
`update_relations_from_node`'s dataset half.

**To settle:**

1. **Does anything outside this repo read `nodes_nodedataset`?** Grep says no
   in-repo readers, but a dashboard, notebook or ops script is invisible to that.
2. **Is `DatasetPort` populated everywhere `NodeDataset` is?** `DatasetPort` rows
   are written by the spec sync (`nodes/spec_sync.py:265`) and the runtime export;
   `NodeDataset` is written from `update_relations_from_node`, only for `DBDataset`
   instances. Confirm no path populates one and not the other before removing the
   older one — an instance that has never been synced would lose its protection.
3. **Timing** relative to the model-editor work, since that is the code most
   likely to be touching these tables concurrently.

**Effort:** small change, wide blast radius. Needs a migration and a careful look
at point 2.

---

## 3. One command for a dataset update

**The problem.** Updating a deployed dataset is currently a sequence a person has to
remember and get in the right order: check the pin, delete or refresh the row,
re-import, re-sync the instance so ports and node links are rebuilt, and verify
nothing else broke. Getting the order wrong produces errors that point somewhere
else entirely — importing from a stale commit surfaces two steps later as
`No metric X in dataset Y` from `sync_instance_to_db`.

**Proposal.** `python manage.py update_dataset <instance> <ds_id>...`, wrapping:
diagnose (the existing `--plan`) → import → `sync_instance_to_db` → report what
changed, including which ports were rebuilt. Two phases, so the diagnosis can be
read and approved before anything is written.

**To settle:**

1. **Does it own the whole flow or just sequence it?** Calling
   `sync_instance_to_db` re-parses the YAML and rewrites the instance's editor
   tables — fine today, but as the model editor becomes authoritative, a dataset
   update that silently rewrites the editor graph from YAML would be destructive.
   This is the same question as item 2's timing, and probably decides whether this
   command should exist in this shape at all.
2. **Should it verify?** Recomputing the affected nodes and diffing against the
   previous outputs would catch a bad import immediately rather than at the next
   page load. That is most of the value and most of the work.
3. **Where does it run?** The current flow is a shell on production. A command
   that can be triggered from the admin would remove the shell requirement, but
   needs a permissions story.

**Effort:** small if it only sequences existing commands; the verification step in
point 2 is a separate piece of work.
