### PR TITLE
NZC: Flatten freight_transport_emissions health-module edges scope

### DIFF
--- a/configs/dut-transport-nzc.yaml
+++ b/configs/dut-transport-nzc.yaml
@@ -623,6 +623,8 @@ nodes:
       flatten: true
   - id: freight_transport_emissions
     from_dimensions:
+    - id: scope
+      flatten: true
     - id: transport_mode
       categories: [light_trucks]
       flatten: true

--- a/configs/lappeenranta-nzc.yaml
+++ b/configs/lappeenranta-nzc.yaml
@@ -349,6 +349,8 @@ nodes:
       flatten: true
   - id: freight_transport_emissions
     from_dimensions:
+    - id: scope
+      flatten: true
     - id: transport_mode
       categories: [light_trucks]
       flatten: true


### PR DESCRIPTION
Fixes Sentry PATHS-BACKEND-7TA:

  NodeError: Node road_transport_emissions_intermediate: Dimensions do
  not match with freight_transport_emissions (['scope'] vs. [])

Root cause: c0205c6f ("Cork: Make sectors more GPC-like. Also, add some categories to nzc") added `scope` to the input/output dimensions of freight_transport_emissions in the shared configs/nzc.yaml. Cork's own copy of the city-specific health-module bridge node got a matching `scope: flatten: true` on its freight edge, but the two other instances that include nzc.yaml and define the same bridge node did not. Their edges flatten only transport_mode/pollutant/energy_carrier, so `scope` survives into an accumulator that has no dimensions at all, and the dimension check in _add_nodes_impl rejects it.

Add the missing `scope` flatten to both, matching cork-nzc.yaml.

Verified: transport_co2_for_health reproduced the exact NodeError before the change and computes cleanly after it for lappeenranta-nzc. For dut-transport-nzc the mismatch is likewise gone, but that instance still fails earlier on an unrelated pre-existing issue.

Other freight_transport_emissions references define the node locally without `scope` and remain internally consistent.

ffffff