### PR TITLE
Make dataset problem listings use category labels rather than ids

### DIFF
--- a/datasets/graphql/types.py
+++ b/datasets/graphql/types.py
@@ -516,16 +516,15 @@ class DatasetType(UserPermissionsMixin):
             return []
         from datasets.validation import load_violations
         from nodes.dataset_materialization import ensure_dataset_materializations
-        from nodes.graphql.types.problems import DatasetValidationViolationType
+        from nodes.graphql.types.problems import DatasetValidationViolationType, build_coordinate_labels
 
         materializations = ensure_dataset_materializations([root._model])
         materialization = materializations.get(root._model.pk)
         if materialization is None:
             return []
-        return [
-            DatasetValidationViolationType.from_violation(violation)
-            for violation in load_violations(materialization.validation_violations)
-        ]
+        violations = load_violations(materialization.validation_violations)
+        labels = build_coordinate_labels(violations)
+        return [DatasetValidationViolationType.from_violation(violation, labels) for violation in violations]
 
     @sb.field(graphql_type=list[Annotated['DatasetPortType', sb.lazy('nodes.graphql.types.graph')]])
     @staticmethod

--- a/nodes/graphql/types/instance.py
+++ b/nodes/graphql/types/instance.py
@@ -338,11 +338,11 @@ class InstanceEditorFields:
     @staticmethod
     def dataset_validation_violations(root: 'InstanceEditorFields') -> list[DatasetValidationViolationType]:
         from nodes.dataset_materialization import collect_instance_dataset_violations
+        from nodes.graphql.types.problems import build_coordinate_labels
 
-        return [
-            DatasetValidationViolationType.from_violation(violation)
-            for violation in collect_instance_dataset_violations(root._config)
-        ]
+        violations = collect_instance_dataset_violations(root._config)
+        labels = build_coordinate_labels(violations)
+        return [DatasetValidationViolationType.from_violation(violation, labels) for violation in violations]
 
     @sb.field(
         graphql_type=list[InstanceProblemInterface],

--- a/nodes/graphql/types/problems.py
+++ b/nodes/graphql/types/problems.py
@@ -40,6 +40,76 @@ class InstanceProblemInterface:
 class DatasetDimensionCoordinateType:
     dimension: str = sb.field(description='Dimension column identifier in the dataset.')
     category: str = sb.field(description='Category identifier within the dimension.')
+    dimension_label: str = sb.field(
+        description="The dimension's label in the active language; falls back to the identifier when unresolvable."
+    )
+    category_label: str = sb.field(
+        description="The category's label in the active language; falls back to the identifier when unresolvable."
+    )
+
+
+#: ``(dataset_uuid, dimension column, category identifier) -> (dimension label, category label)``.
+type CoordinateLabels = dict[tuple[UUID | None, str, str], tuple[str, str]]
+
+
+def build_coordinate_labels(violations: Iterable[RuleViolation]) -> CoordinateLabels:
+    """
+    Resolve localized labels for the dimension coordinates named by ``violations``.
+
+    Violations are persisted with identifiers only: a materialization is shared
+    across users and languages, and ``RuleViolation.key`` diffs on the identifier
+    coordinates at edit time. Labels are therefore a presentation concern resolved
+    here, in the active language, rather than baked into the stored payload.
+
+    One query pass over the datasets involved, so a violation list costs a fixed
+    number of queries rather than one per coordinate.
+    """
+    from kausal_common.datasets.models import Dataset, DatasetSchemaDimension, DimensionScope
+
+    dataset_uuids = {violation.dataset_uuid for violation in violations if violation.dataset_uuid is not None}
+    if not dataset_uuids:
+        return {}
+    datasets = list(
+        Dataset.objects
+        .filter(uuid__in=dataset_uuids)
+        .select_related('schema')
+        .only('uuid', 'schema', 'scope_content_type', 'scope_id')
+    )
+    labels: CoordinateLabels = {}
+    for dataset in datasets:
+        schema = dataset.schema
+        if schema is None or dataset.scope_id is None:
+            continue
+        # The dataframe column is DatasetSchemaDimension.column_name when set and the
+        # scoped dimension identifier otherwise -- the same rule the evaluator applies
+        # when it records the coordinate.
+        scopes = {
+            scope.dimension_id: scope
+            for scope in DimensionScope.objects
+            .filter(
+                scope_content_type=dataset.scope_content_type,
+                scope_id=dataset.scope_id,
+                dimension_id__in=schema.dimensions.values_list('dimension_id', flat=True),
+            )
+            .select_related('dimension')
+            .prefetch_related('dimension__categories')
+        }
+        for schema_dimension in DatasetSchemaDimension.objects.filter(schema=schema).only('dimension_id', 'column_name'):
+            scope = scopes.get(schema_dimension.dimension_id)
+            if scope is None:
+                continue
+            column = schema_dimension.column_name or scope.identifier
+            if not column:
+                continue
+            dimension_label = scope.dimension.name_i18n or column
+            for category in scope.dimension.categories.all():
+                if category.identifier is None:
+                    continue
+                labels[(dataset.uuid, column, category.identifier)] = (
+                    dimension_label,
+                    category.label_i18n or category.identifier,
+                )
+    return labels
 
 
 @sb.type(
@@ -59,7 +129,18 @@ class DatasetValidationViolationType(InstanceProblemInterface):
     requirement_group: str | None = sb.field(description='Named required-combination group, when applicable.')
 
     @classmethod
-    def from_violation(cls, violation: RuleViolation) -> Self:
+    def from_violation(cls, violation: RuleViolation, labels: CoordinateLabels | None = None) -> Self:
+        labels = labels if labels is not None else {}
+
+        def coordinate(dimension: str, category: str) -> DatasetDimensionCoordinateType:
+            dimension_label, category_label = labels.get((violation.dataset_uuid, dimension, category), (dimension, category))
+            return DatasetDimensionCoordinateType(
+                dimension=dimension,
+                category=category,
+                dimension_label=dimension_label,
+                category_label=category_label,
+            )
+
         return cls(
             code=violation.kind,
             message=violation.message,
@@ -71,10 +152,7 @@ class DatasetValidationViolationType(InstanceProblemInterface):
             dataset_uuid=violation.dataset_uuid,
             dataset_identifier=violation.dataset_identifier,
             years=list(violation.years),
-            coordinates=[
-                DatasetDimensionCoordinateType(dimension=dimension, category=category)
-                for dimension, category in violation.categories.items()
-            ],
+            coordinates=[coordinate(dimension, category) for dimension, category in violation.categories.items()],
             combination_ids=list(violation.combination_ids),
             requirement_group=violation.requirement_group,
         )
@@ -92,4 +170,6 @@ class DatasetValidationViolationsType:
 
     @classmethod
     def from_violations(cls, violations: Iterable[RuleViolation]) -> Self:
-        return cls(violations=[DatasetValidationViolationType.from_violation(violation) for violation in violations])
+        found = list(violations)
+        labels = build_coordinate_labels(found)
+        return cls(violations=[DatasetValidationViolationType.from_violation(violation, labels) for violation in found])


### PR DESCRIPTION
# Description

I made a functionality that uses actual category labels in the relevant language rather than category ids. This update also has changes in kausal-paths-ui.


Backend (3 files, uncommitted)

DatasetDimensionCoordinate gains dimensionLabel and categoryLabel. Labels resolve at the GraphQL boundary, not at evaluation time — deliberately: a materialization is shared across users and languages, and RuleViolation.key baseline-diffs on the identifier coordinates at edit time, so baking labels into the stored payload would be wrong twice over.

build_coordinate_labels(violations) does one query pass over the datasets involved, so a violation list costs a fixed number of queries rather than one per coordinate. It reproduces the evaluator's own column rule — DatasetSchemaDimension.column_name when set, the scoped dimension identifier otherwise — so the lookup key matches what the evaluator recorded. Falls back to the identifier when unresolvable. Wired into all three construction sites: the per-dataset resolver, the instance-wide one, and the publish-mutation payload.

UI (5 files, on feat/dataset-validation)

Renders coordinates.map(c => c.categoryLabel).join(' + ') instead of the group id, falling back to the group id. Types regenerated. I also reworded both strings, since "Kategoriegruppe" no longer describes what the placeholder holds:

▎ Für Value fehlt ein erforderlicher Wert für „Industrie + Strom“ in den Jahren 2020, 2021, 2022, 2023. Eine ausdrücklich eingetragene Null gilt als Wert.

Verified against the real data — all 8 violations resolve: "Private Haushalte + Strom", "Industrie + Erdgas", "Private Haushalte + Fernwärme", etc. dimensionLabel is exposed too (giving "Sektoren: Industrie + Energieträger: Strom") but unused for now — available if you want it in a tooltip or a grid.

Two things you should know

English will show German labels, and it's a data problem, not a code one. MODELTRANS_FALLBACK/LANGUAGE_CODE make en the default language, so modeltrans reads the base column for English. These categories store German in the base column (label='Industrie') with i18n={'label_en': 'Industry'} duplicating English into the JSON — so English resolves to the base column and gets German, while German resolves by fallback and gets it right by accident. I verified the mechanism itself works: an in-memory category with label_de set resolves correctly under de and fi. So this affects anything rendering these labels, not just validation messages, and it's pre-existing. Fixing it means either flipping the storage for de-default instances or setting label_de explicitly.

The UI branch won't lint clean until the backend is deployed. eslint's GraphQL plugin resolves the schema via graphql.config.ts, which falls back to https://api.paths.kausal.dev when no local schema.graphql exists — and production doesn't have the new fields yet, so it reports Cannot query field "dimensionLabel". With a local schema export in place it's 0 errors, 9 pre-existing deprecation warnings. If you want it quiet locally: python manage.py export_schema paths.schema > ~/devel/kausal-paths-ui/schema.graphql (note that filename isn't gitignored, so I removed mine after use).

Backend: 1774 tests pass, ruff clean, Run Mypy...Passed. UI: tsc reports no errors in the files I touched (86 total, all pre-existing elsewhere), and the generated diff is purely the two added fields. One thing to flag — I used npm run graphql-codegen in what is a pnpm project, which rewrote packageManager in package.json; I reverted that, but pnpm isn't on PATH here, so you may want to re-run codegen with pnpm yourself if that matters for the lockfile.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Additional Notes
Any additional information that reviewers should know about this PR.
