### PR TITLE
Restore placeholder values on the Additional Historical Data tab

### DIFF
--- a/frameworks/datasets.py
+++ b/frameworks/datasets.py
@@ -214,6 +214,9 @@ class FrameworkMeasureDVCDataset2(DVCDataset):
     payload_ref: DatasetPayloadRef | None = field(default=None)
     payload_store: DatasetPayloadStore | None = field(default=None)
 
+    _uuid_frame: ppl.PathsDataFrame | None = field(default=None, init=False, repr=False, compare=False)
+    _uuid_frame_loaded: bool = field(default=False, init=False, repr=False, compare=False)
+
     @classmethod
     def from_def(  # type: ignore[override]
         cls,
@@ -249,6 +252,49 @@ class FrameworkMeasureDVCDataset2(DVCDataset):
         df = self.post_process(df)
         if self.cache_key:
             self.cache_set(df)
+        return df
+
+    def get_uuid_frame(self) -> ppl.PathsDataFrame | None:
+        """
+        Return this binding's frame as it stands *before* the measure-datapoint overlay.
+
+        ``post_process`` folds in the city's own MeasureDataPoints and then drops ``uuid``
+        (see ``_override_with_measure_datapoints``), which is the one column that says
+        which measure a row belongs to. Stopping short of it -- after the source load and
+        the binding's ``column`` selection and filters -- leaves the measure linkage
+        intact, which is what the placeholder lookup reads this for.
+
+        Returns ``None`` when the binding has no ``uuid`` column, i.e. it carries no
+        measure linkage at all.
+        """
+        if self._uuid_frame_loaded:
+            return self._uuid_frame
+
+        if self.payload_ref is not None:
+            assert self.payload_store is not None
+            df = self.payload_store.get_dataframe(self.payload_ref).copy()
+        elif self.db_dataset_obj is not None:
+            from nodes.datasets import DBDataset
+
+            df = DBDataset.deserialize_df(self.db_dataset_obj)
+        else:
+            dvc_ds = self.context.load_dvc_dataset(self.input_dataset or self.id)
+            assert dvc_ds.df is not None
+            df = self._convert_dvc_dataset(dvc_ds)
+        df = self._filter_and_process_df(df)
+        # Deliberately short of `post_process`: this frame is only ever read to find out
+        # *which* measures the binding carries and under which categories, and the overlay
+        # there would drop the uuid column that answers exactly that. The values a measure
+        # displays come from the node's output, not from here.
+        # Memoise only once the load has actually succeeded, so a transient source failure
+        # is not remembered as "this binding carries no measures".
+        self._uuid_frame_loaded = True
+        if 'uuid' not in df.columns:
+            return None
+        # Match the normalisation `_override_with_measure_datapoints` applies before it
+        # joins against the DB, so callers can compare against a MeasureTemplate UUID.
+        df = df.with_columns(pl.col('uuid').cast(pl.String).str.replace_all('_', '-'))
+        self._uuid_frame = df
         return df
 
     @property  # Override parent @cached_property: key must vary per scenario

--- a/frameworks/models.py
+++ b/frameworks/models.py
@@ -1,7 +1,7 @@
 import re
 import uuid
-from dataclasses import dataclass
-from functools import cached_property
+from dataclasses import dataclass, replace
+from functools import cached_property, partial
 from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -37,7 +37,7 @@ from paths.types import CacheablePathsModel, PathsModel, PathsQuerySet
 from paths.utils import IdentifierField, UnitField
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from rich.repr import RichReprResult
 
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
     from paths.schema_context import PathsGraphQLContext
 
+    from frameworks.datasets import FrameworkMeasureDVCDataset2
     from frameworks.permissions import MeasureTemplatePermissionPolicy
     from nodes.gpc import DatasetNode
     from nodes.instance import Instance
@@ -72,6 +73,24 @@ if TYPE_CHECKING:
 class NodeDimensionSelection:
     node_id: str
     dimensions: dict[str, str] | None
+    dataset_index: int | None = None
+    """
+    Index of the ``city_data`` binding this measure was found through, if it was.
+
+    Values come from the node's output either way. What the index records is *how* the
+    measure was matched -- ``None`` for the legacy path, where the node is a thin wrapper
+    over one dataset and its class is the whole story -- which is what tells the resolver
+    whether the node's unit can be trusted to be the client's.
+    """
+
+    metric_col: str | None = None
+    """
+    Output column holding this measure's series, when the node emits more than one.
+
+    A multi-metric node renames ``Value`` to the metric column, so there is nothing for
+    the resolver to read under the usual name. ``None`` means the node emits a single
+    metric and ``Value`` is it.
+    """
 
 
 class FrameworkQuerySet(PathsQuerySet['Framework']):
@@ -1182,26 +1201,262 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
             result.append((_uuid, dims))
         return result
 
-    @cached_property
-    def measure_template_uuid_to_node_dimension_selection(self) -> Mapping[str, NodeDimensionSelection]:
+    @staticmethod
+    def _get_measure_template_uuids_from_binding(
+        ds: FrameworkMeasureDVCDataset2,
+    ) -> list[tuple[str, dict[str, str] | None]]:
+        """
+        Read the (uuid, dimension categories) pairs a single ``city_data`` binding carries.
+
+        The ``DatasetNode`` sibling of this method has to undo the GPC sheet's
+        human-readable dimension labels via ``convert_names_to_ids``. Here the frame has
+        already been through the binding pipeline, so its dimension columns are ids and
+        can be read straight off ``dim_ids``.
+
+        Categories are the *only* handle the resolver has on a measure. The values come
+        from the node's output, which carries no uuid -- the binding is read to find the
+        measure, not to serve it -- so a uuid these cannot pin down to one series is left
+        unmapped rather than answered with someone else's numbers:
+
+        - a uuid spread over several categories has no single series;
+        - a uuid whose categories do not exclude another uuid's rows cannot be told from
+          it, and goes.
+
+        The second test is containment, not equality. A selector matches every row that
+        agrees with the categories it names and says nothing about the rest, so a selector
+        contained in another is the *broader* one: ``{transport_mode: cars}`` sweeps up
+        ``{transport_mode: cars, energy_carrier: electricity}`` as well as its own rows.
+        Equal selectors are the symmetric case, each contained in the other, and both go.
+        The narrower one survives -- nothing outside it satisfies its extra category.
+
+        The empty selector falls out of the same rule: it is contained in everything, so
+        it is fine alone in a binding and ambiguous beside anything else.
+
+        Only the uuids actually in conflict are dropped; the rest of the binding stands.
+        Null categories are discarded: they mean the column does not apply to this measure,
+        and filtering the node's output for a null category matches nothing.
+        """
+        df = ds.get_uuid_frame()
+        if df is None:
+            return []
+        dim_ids = [d for d in df.dim_ids if d != 'uuid']
+
+        categories_by_uuid: dict[str, set[tuple[str, ...]]] = {}
+        for _uuid, *categories in df.select(['uuid', *dim_ids]).iter_rows():
+            if _uuid is None:
+                continue
+            categories_by_uuid.setdefault(_uuid, set()).add(tuple(categories))
+
+        selectors: dict[str, dict[str, str]] = {}
+        ambiguous: list[str] = []
+        for _uuid, cats in categories_by_uuid.items():
+            if len(cats) > 1:
+                ambiguous.append(_uuid)
+                continue
+            selectors[_uuid] = {dim: cat for dim, cat in zip(dim_ids, next(iter(cats)), strict=True) if cat is not None}
+
+        too_broad = {
+            _uuid
+            for _uuid, sel in selectors.items()
+            if any(other != _uuid and sel.items() <= osel.items() for other, osel in selectors.items())
+        }
+        ambiguous.extend(sorted(too_broad))
+        result: list[tuple[str, dict[str, str] | None]] = [
+            (_uuid, sel or None) for _uuid, sel in selectors.items() if _uuid not in too_broad
+        ]
+        if ambiguous:
+            by = f'by {"/".join(dim_ids)}' if dim_ids else 'and carries no dimension to tell them apart'
+            msg = (
+                f'Dataset {ds.id} does not pin MeasureTemplate(s) {", ".join(sorted(ambiguous))} '
+                f'to one series {by}; no placeholder values for them'
+            )
+            logger.warning(msg)
+            sentry_sdk.capture_message(msg)
+        return result
+
+    @staticmethod
+    def _prefer_historical_bindings(
+        instance: Instance,
+        values: list[NodeDimensionSelection],
+    ) -> list[NodeDimensionSelection]:
+        """
+        Drop binding selections that lost a same-uuid tie on tags; lower rank wins.
+
+        A single dataset commonly holds one uuid column beside several value columns --
+        the historical series, the decarbonisation goal, and so on -- which the config
+        binds separately. All of them then claim the same uuid. The placeholder is only
+        ever asked for years at or before today (see ``resolve_placeholder_data_points``),
+        so the historical series is the one that answers the question.
+
+        The ranking runs *per node*, and settles only the choice this tie-break was added
+        for: which column of one dataset a node should be read through. Across nodes it
+        decides nothing and must not, because the node-id heuristics that follow know
+        things it does not. An action binds a column as ``historical`` while the level node
+        downstream of it binds the same column untagged; ranking the two together lets the
+        action win on the tag and the ``*_observed`` node never reaches the preference that
+        exists for it -- and since the action reports a baseline delta, the cell then shows
+        nothing at all.
+
+        A legacy ``DatasetNode`` selection has no binding to rank, and giving it a
+        synthetic rank would evict it just as wrongly, so it is always passed through.
+        """
+
+        def rank(sel: NodeDimensionSelection) -> int:
+            assert sel.dataset_index is not None
+            tags = instance.context.nodes[sel.node_id].input_dataset_instances[sel.dataset_index].tags
+            if 'historical' in tags or 'observed' in tags:
+                return 0
+            if 'goal' in tags:
+                return 2
+            return 1
+
+        best_by_node: dict[str, int] = {}
+        for v in values:
+            if v.dataset_index is None:
+                continue
+            best_by_node[v.node_id] = min(rank(v), best_by_node.get(v.node_id, rank(v)))
+        return [v for v in values if v.dataset_index is None or rank(v) == best_by_node[v.node_id]]
+
+    @staticmethod
+    def _prefer_a_level_over_a_delta(
+        instance: Instance,
+        values: list[NodeDimensionSelection],
+    ) -> list[NodeDimensionSelection]:
+        """
+        Drop candidates that can only report movement, when one can report a level.
+
+        A cell asks what the plan is for a year, and a node declaring
+        ``output_is_baseline_delta`` answers a different question -- how far the plan moves
+        from the baseline. Where a level node claims the same uuid, as it commonly does
+        when an action and the node it feeds bind the same column, that node is the answer.
+        The node-id heuristics cannot see the difference: neither ``new_building_shares``
+        nor ``a32_new_building_improvements`` carries a suffix they recognise.
+
+        Falls through untouched when every candidate reports movement, leaving the
+        resolver to withhold the value rather than present a delta as a level.
+        """
+        levels = [v for v in values if not instance.context.nodes[v.node_id].output_is_baseline_delta]
+        return levels or values
+
+    @staticmethod
+    def _prefer_the_full_trajectory(instance: Instance, sel: NodeDimensionSelection) -> NodeDimensionSelection:
+        """
+        Point a measure at the node that carries its whole trajectory, where one exists.
+
+        A goal node holds only the target end of a series -- in NZC it begins at the target
+        year -- while placeholders are only ever asked for years at or before today, so
+        such a measure has nothing to show. Its uuid lands there because the historical
+        column of the same dataset is null for it, not because the goal series is what the
+        cell wants.
+
+        Which node carries the whole series is a fact about the graph, not about the name:
+        a goal feeds an action, and the action combines it with the historical series and
+        emits the trajectory. Follow ``goal -> action -> output``. Reading a ``_goal``
+        suffix instead would mean a rename silently changed the numbers a city sees, and
+        would claim a relationship for any node that merely ends that way.
+
+        An action commonly feeds several nodes -- ``a21_optimised_logistics`` emits both a
+        utilisation percentage and vehicle kilometres -- so take the one measuring the same
+        quantity as the goal, and only when it can serve the selection's categories and
+        metric. Where the graph does not answer unambiguously nothing moves: the measure
+        keeps its node and shows nothing, as before.
+        """
+        from nodes.actions.action import ActionNode
+
+        node = instance.context.nodes.get(sel.node_id)
+        if node is None or node.unit is None:
+            return sel
+        quantity = node.unit
+
+        def can_serve(target: Node) -> bool:
+            if target.unit is None or not quantity.is_compatible_with(target.unit):
+                return False
+            if sel.dimensions and not set(sel.dimensions) <= set(target.output_dimensions):
+                return False
+            return sel.metric_col is None or sel.metric_col in {m.column_id for m in target.output_metrics.values()}
+
+        targets = {
+            target.id
+            for action in node.output_nodes
+            if isinstance(action, ActionNode)
+            for target in action.output_nodes
+            if can_serve(target)
+        }
+        if len(targets) != 1:
+            return sel
+        return replace(sel, node_id=targets.pop())
+
+    @staticmethod
+    def _claimed_uuids(
+        describe: str,
+        read: Callable[[], list[tuple[str, dict[str, str] | None]]],
+    ) -> list[tuple[str, dict[str, str] | None]]:
+        """
+        Read one source's measure claims, treating a failure as "claims nothing".
+
+        This mapping is built once for the whole framework config and every measure waits
+        on it, so an exception escaping here is not one blank cell -- it fails
+        ``correspondingNode`` and ``placeholderDataPoints`` for every measure on the tab,
+        and being a cached_property it is not even cached, so each measure retries the
+        same broken load. A missing DVC dataset or a column removed out from under a
+        binding should cost that binding's measures, nothing more.
+        """
+        try:
+            return read()
+        except Exception as exc:
+            msg = f'Cannot read measure UUIDs from {describe}: {exc}'
+            logger.warning(msg)
+            sentry_sdk.capture_exception(exc)
+            return []
+
+    def _get_node_dimension_selections(self, node_id: str, node: Node) -> list[tuple[str, NodeDimensionSelection]]:
+        """Return every (uuid, selection) pair one node claims, by whichever route it carries city data."""
+        from frameworks.datasets import FrameworkMeasureDVCDataset2
         from nodes.gpc import DatasetNode
 
+        # Intentionally test for concrete type, filter out subclasses
+        if type(node) is DatasetNode:
+            # Workaround to filter viz helper nodes
+            # FIXME: Implement this better later
+            if node.get_parameter_value_str('uuid', required=False):
+                return []
+            return [
+                (_uuid, NodeDimensionSelection(node_id=node_id, dimensions=dimensions))
+                for _uuid, dimensions in self._claimed_uuids(f'node {node_id}', partial(self._get_measure_template_uuids, node))
+            ]
+
+        # Nodes that take their city data through a tagged binding rather than by being a
+        # DatasetNode. The class-based branch above cannot see these, and since f2d6be20
+        # the NZC model is built entirely out of them.
+        selections: list[tuple[str, NodeDimensionSelection]] = []
+        for index, ds in enumerate(node.input_dataset_instances):
+            if 'city_data' not in ds.tags or not isinstance(ds, FrameworkMeasureDVCDataset2):
+                continue
+            # A multi-metric node renames Value to the metric column, so the resolver has
+            # to be told which one this binding feeds. The config says so by tagging the
+            # binding with the metric's id alongside historical/goal/city_data.
+            metric = next((tag for tag in ds.tags if tag in node.output_metrics), None)
+            metric_col = node.output_metrics[metric].column_id if metric is not None else None
+            claims = self._claimed_uuids(
+                f'binding {index} ({ds.id}) of node {node_id}',
+                partial(self._get_measure_template_uuids_from_binding, ds),
+            )
+            selections += [
+                (
+                    _uuid,
+                    NodeDimensionSelection(node_id=node_id, dimensions=dimensions, dataset_index=index, metric_col=metric_col),
+                )
+                for _uuid, dimensions in claims
+            ]
+        return selections
+
+    @cached_property
+    def measure_template_uuid_to_node_dimension_selection(self) -> Mapping[str, NodeDimensionSelection]:
         measure_template_uuid_to_multiple_node_dimensions_selections: dict[str, list[NodeDimensionSelection]] = dict()
         instance = self.instance_config.get_instance()
         for node_id, node in instance.context.nodes.items():
-            # Intentionally test for concrete type, filter out subclasses
-            if type(node) is not DatasetNode:
-                continue
-            # Workaround to filter viz helper nodes
-            # FIXME: Implement this better later
-            uuid_param = node.get_parameter_value_str('uuid', required=False)
-            if uuid_param:
-                continue
-            measure_template_uuids = self._get_measure_template_uuids(node)
-            for _uuid, dimensions in measure_template_uuids:
-                measure_template_uuid_to_multiple_node_dimensions_selections.setdefault(_uuid, []).append(
-                    NodeDimensionSelection(node_id=node_id, dimensions=dimensions)
-                )
+            for _uuid, selection in self._get_node_dimension_selections(node_id, node):
+                measure_template_uuid_to_multiple_node_dimensions_selections.setdefault(_uuid, []).append(selection)
 
         re_historical = re.compile(r'.*_historical$')
         re_observed = re.compile(r'.*_observed$')
@@ -1211,16 +1466,27 @@ class FrameworkConfig(CacheablePathsModel['FrameworkConfigCacheData'], UserModif
             if len(values) == 1:
                 measure_template_uuid_to_single_node_dimension_selection[_uuid] = values[0]
                 continue
-            accepted_values = [v for v in values if re_observed.match(v.node_id)]
+            # The node-id heuristics below cannot separate bindings that live on the same
+            # node, which is the usual shape of a tie now: one dataset, one uuid column,
+            # several value columns. Narrow by binding tag first, and only fall through to
+            # the node-id heuristics if that still leaves a genuine choice between nodes.
+            candidates = self._prefer_a_level_over_a_delta(instance, self._prefer_historical_bindings(instance, values))
+            if len(candidates) == 1:
+                measure_template_uuid_to_single_node_dimension_selection[_uuid] = candidates[0]
+                continue
+            accepted_values = [v for v in candidates if re_observed.match(v.node_id)]
             if len(accepted_values) != 1:
-                accepted_values = [v for v in values if not re_historical.match(v.node_id)]
+                accepted_values = [v for v in candidates if not re_historical.match(v.node_id)]
             if len(accepted_values) == 1:
                 measure_template_uuid_to_single_node_dimension_selection[_uuid] = accepted_values[0]
                 continue
-            msg = f'Cannot find single Node to match MeasureTemplate {_uuid}: {", ".join([n.node_id for n in values])}'
+            msg = f'Cannot find single Node to match MeasureTemplate {_uuid}: {", ".join([n.node_id for n in candidates])}'
             logger.warning(msg)
             sentry_sdk.capture_message(msg)
-        return measure_template_uuid_to_single_node_dimension_selection
+        return {
+            _uuid: self._prefer_the_full_trajectory(instance, sel)
+            for _uuid, sel in measure_template_uuid_to_single_node_dimension_selection.items()
+        }
 
 
 class MeasureQuerySet(PathsQuerySet['Measure']):

--- a/frameworks/schema.py
+++ b/frameworks/schema.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 from graphql import GraphQLError
 
 import sentry_sdk
+from loguru import logger
 
 from kausal_common.graphene import DjangoNode, DjangoNodeMeta
 from kausal_common.models.general import public_fields
@@ -22,10 +23,11 @@ from kausal_common.strawberry.registry import register_strawberry_type
 
 from paths.graphql_types import resolve_unit
 
-from nodes.constants import YEAR_COLUMN
+from nodes.constants import VALUE_COLUMN, YEAR_COLUMN
 from nodes.exceptions import NodeComputationError
 from nodes.models import InstanceConfig
 from nodes.schema import NodeInterface
+from nodes.units import unit_registry
 
 from .models import (
     Framework,
@@ -46,6 +48,7 @@ if TYPE_CHECKING:
 
     from paths.types import PathsGQLInfo as GQLInfo
 
+    from common import polars as ppl
     from frameworks.models import FrameworkDimensionCategory, NodeDimensionSelection
     from nodes.context import Context
     from nodes.graphql.types.instance import InstanceType
@@ -249,8 +252,72 @@ class MeasureType(DjangoNode[Measure]):
         return node[0]
 
     @staticmethod
+    def _get_placeholder_df(
+        measure: Measure,
+        node: Node,
+        selection: NodeDimensionSelection,
+    ) -> ppl.PathsDataFrame | None:
+        """
+        Return the frame the measure's planned values are read from.
+
+        Both paths read the node's output. The plan value for a given year is not written
+        down anywhere: the city-data datasets carry a single authored row per measure, at
+        the baseline year, and the trajectory across the years the sheet asks about is
+        what the model computes from it. The binding is how the measure was *found*, not
+        where its values live.
+
+        The node's own unit is only guaranteed to be the one the client formats against on
+        the legacy path, where the node wraps one dataset. On the binding path it can
+        differ by scale -- kg against t -- and converting is the difference between a right
+        and a thousand-times-wrong number.
+
+        Where the two are not convertible at all the annotations disagree rather than the
+        magnitudes: a rate node in ``%/a`` against a MeasureTemplate in ``%``. The legacy
+        path never converted and cities read those values happily, so pass the number
+        through as it always was rather than blank the cell over a units quibble.
+        """
+        # TEMPORARY, pending confirmation of what a delta-valued cell should show. A node
+        # declaring output_is_baseline_delta yields movement from the baseline year, so in
+        # a cell asking for a share a grey `-3.7` reads as authoritative and means the
+        # planned reduction instead. These measures were already blank before this branch,
+        # so withholding them changes nothing for a city while the question is open.
+        # Delete this block to restore them, or convert the delta into a level here.
+        if selection.dataset_index is not None and node.output_is_baseline_delta:
+            logger.info(
+                f'Node {node.id} reports change from the baseline year, not a level; withholding '
+                f'placeholders for measure {measure.measure_template.uuid}'
+            )
+            return None
+        df = node.get_output_pl()
+        if selection.dataset_index is None:
+            return df
+        if VALUE_COLUMN not in df.columns:
+            # A multi-metric node renamed Value to the metric column; the binding's tags
+            # said which one, so read that and put it back under the name the rest of the
+            # resolver expects.
+            if selection.metric_col is None or selection.metric_col not in df.columns:
+                logger.info(
+                    f'Node {node.id} outputs metrics {df.metric_cols} rather than a single value; '
+                    f'cannot tell which one measure {measure.measure_template.uuid} means'
+                )
+                return None
+            df = df.select_metrics(selection.metric_col, VALUE_COLUMN)
+        node_unit = df.get_unit(VALUE_COLUMN)
+        # MeasureTemplate.unit hands back a plain string, and comparing a pint Unit against
+        # one makes pint parse it mid-comparison and trip an assertion. Parse it ourselves.
+        template_unit = unit_registry.parse_units(str(measure.measure_template.unit))
+        if node_unit == template_unit:
+            return df
+        if not node_unit.is_compatible_with(template_unit):
+            logger.info(
+                f'Measure {measure.measure_template.uuid} is {template_unit} but node {node.id} outputs '
+                f'{node_unit}; passing values through unconverted'
+            )
+            return df
+        return df.ensure_unit(VALUE_COLUMN, template_unit)
+
+    @staticmethod
     def resolve_placeholder_data_points(root: Measure, info: GQLInfo) -> list[PlaceHolderDataPoint]:
-        import polars as pl
 
         node, node_dimension_selection = MeasureType._find_corresponding_node(root)
         if node is None or node_dimension_selection is None:
@@ -258,20 +325,53 @@ class MeasureType(DjangoNode[Measure]):
         fwc, context = MeasureType._get_fwc_and_context(root)
         with context.get_default_scenario().override():
             try:
-                df = node.get_output_pl()
+                df = MeasureType._get_placeholder_df(root, node, node_dimension_selection)
             except NodeComputationError as e:
                 sentry_sdk.capture_exception(e)
                 return []
-        df = df.filter((pl.col(YEAR_COLUMN) > fwc.baseline_year) & (pl.col(YEAR_COLUMN) <= timezone.now().year))
-        dimensions = node_dimension_selection.dimensions
-        if dimensions:
-            df = df.filter(**dimensions)
-        result = []
-        for d in df.select(pl.col('Year'), pl.col('Value')).to_dicts():
-            year = d['Year']
-            value = d['Value']
-            result.append(PlaceHolderDataPoint(year=year, value=value))
-        return result
+        if df is None:
+            return []
+        return MeasureType._narrow_to_placeholders(
+            df,
+            node_dimension_selection,
+            baseline_year=fwc.baseline_year,
+            last_year=timezone.now().year,
+            label=f'Measure {root.measure_template.uuid} on node {node.id}',
+        )
+
+    @staticmethod
+    def _narrow_to_placeholders(
+        df: ppl.PathsDataFrame,
+        selection: NodeDimensionSelection,
+        *,
+        baseline_year: int,
+        last_year: int,
+        label: str,
+    ) -> list[PlaceHolderDataPoint]:
+        """Cut the node's output down to the one value per year this measure's cell shows."""
+        import polars as pl
+
+        # A multi-metric node outer-joins metrics that span different dimensions, keeping
+        # the rows where the other metrics have nothing to say (see DatasetReduceAction2).
+        # Selecting one metric turns those into null values: they are not this measure's
+        # series, they would count against the one-row-per-year check below, and a null
+        # placeholder is nothing the client can render anyway.
+        df = df.filter(pl.col(VALUE_COLUMN).is_not_null())
+        df = df.filter((pl.col(YEAR_COLUMN) > baseline_year) & (pl.col(YEAR_COLUMN) <= last_year))
+        if selection.dimensions:
+            df = df.filter(**selection.dimensions)
+        if selection.dataset_index is not None and df.get_column(YEAR_COLUMN).is_duplicated().any():
+            # A cell holds one number, so more than one row per year means the selection
+            # failed to pin down a single series. Emitting them all would leave the client
+            # keeping whichever came last; say nothing instead.
+            msg = f'{label} resolves to several rows per year; refusing to guess a placeholder value'
+            logger.warning(msg)
+            sentry_sdk.capture_message(msg)
+            return []
+        return [
+            PlaceHolderDataPoint(year=d[YEAR_COLUMN], value=d[VALUE_COLUMN])
+            for d in df.select(pl.col(YEAR_COLUMN), pl.col(VALUE_COLUMN)).to_dicts()
+        ]
 
 
 class FrameworkConfigType(DjangoNode[FrameworkConfig]):

--- a/frameworks/tests/test_placeholder_lookup.py
+++ b/frameworks/tests/test_placeholder_lookup.py
@@ -1,0 +1,686 @@
+"""Tests for mapping MeasureTemplate UUIDs onto the model nodes that hold their values."""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+import pytest
+
+from common.polars import DataFrameMeta, to_ppdf
+from frameworks.datasets import FrameworkMeasureDVCDataset2
+from frameworks.models import FrameworkConfig, NodeDimensionSelection
+from frameworks.schema import MeasureType
+from nodes.constants import VALUE_COLUMN, YEAR_COLUMN
+from nodes.units import unit_registry
+
+if TYPE_CHECKING:
+    from common.polars import PathsDataFrame
+
+pytestmark = pytest.mark.django_db
+
+UUID_A = '11111111-1111-1111-1111-111111111111'
+UUID_B = '22222222-2222-2222-2222-222222222222'
+UUID_C = '33333333-3333-3333-3333-333333333333'
+
+
+def _frame(rows: list[dict[str, Any]], dims: list[str]) -> PathsDataFrame:
+    df = pl.DataFrame(rows)
+    meta = DataFrameMeta(
+        units={VALUE_COLUMN: unit_registry.parse_units('kWh')},
+        primary_keys=[YEAR_COLUMN, 'uuid', *dims],
+    )
+    return to_ppdf(df, meta)
+
+
+def _binding(df: PathsDataFrame | None, tags: list[str] | None = None) -> Any:
+    return SimpleNamespace(id='ds', tags=tags or [], get_uuid_frame=lambda: df)
+
+
+def _uuids_from_binding(ds: Any) -> list[tuple[str, dict[str, str] | None]]:
+    return FrameworkConfig._get_measure_template_uuids_from_binding(ds)
+
+
+def test_binding_without_uuid_column_claims_nothing():
+    assert _uuids_from_binding(_binding(None)) == []
+
+
+def test_single_uuid_binding_needs_no_dimensions():
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2021, 'uuid': UUID_A, VALUE_COLUMN: 2.0},
+        ],
+        dims=[],
+    )
+    assert _uuids_from_binding(_binding(df)) == [(UUID_A, None)]
+
+
+def test_uuids_are_separated_by_dimension_category():
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2021, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 2.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, 'energy_carrier': 'heat', VALUE_COLUMN: 3.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    assert dict(_uuids_from_binding(_binding(df))) == {
+        UUID_A: {'energy_carrier': 'electricity'},
+        UUID_B: {'energy_carrier': 'heat'},
+    }
+
+
+def test_uuids_sharing_a_dimension_category_are_both_dropped():
+    """
+    Two measures under one category cannot be told apart, so neither is claimed.
+
+    Values come from the node's output, which carries no uuid -- the binding is read to
+    find the measure, not to serve it -- so categories are the only selector, and a shared
+    one would hand both measures the same series.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, 'energy_carrier': 'electricity', VALUE_COLUMN: 3.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    assert _uuids_from_binding(_binding(df)) == []
+
+
+def test_only_the_colliding_uuids_are_dropped():
+    """A collision is not a reason to discard the measures around it."""
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, 'energy_carrier': 'electricity', VALUE_COLUMN: 3.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_C, 'energy_carrier': 'heat', VALUE_COLUMN: 5.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    assert dict(_uuids_from_binding(_binding(df))) == {UUID_C: {'energy_carrier': 'heat'}}
+
+
+def test_null_categories_are_dropped_from_the_selector():
+    """
+    A null category means the column does not apply, not that it should be matched.
+
+    ``filter(energy_carrier=None)`` against the node's output matches nothing, so leaving
+    it in the selector would blank the cell.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'transport_mode': 'cars', 'energy_carrier': None, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, 'transport_mode': 'buses', 'energy_carrier': None, VALUE_COLUMN: 2.0},
+        ],
+        dims=['transport_mode', 'energy_carrier'],
+    )
+    assert dict(_uuids_from_binding(_binding(df))) == {
+        UUID_A: {'transport_mode': 'cars'},
+        UUID_B: {'transport_mode': 'buses'},
+    }
+
+
+def test_uuid_spanning_several_categories_is_skipped():
+    """
+    A cell holds one number, so a measure spread over categories has no single answer.
+
+    Mapping it with no categories to narrow by would emit one point per category per
+    year, and the client would keep whichever arrived last. Its neighbours in the same
+    binding are unaffected.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'heat', VALUE_COLUMN: 2.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, 'energy_carrier': 'heat', VALUE_COLUMN: 3.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    assert dict(_uuids_from_binding(_binding(df))) == {UUID_B: {'energy_carrier': 'heat'}}
+
+
+def test_a_selector_contained_in_another_is_dropped_but_the_narrower_one_stays():
+    """
+    A broader selector sweeps up the narrower one's rows, so it pins nothing.
+
+    UUID_A's null energy_carrier leaves it selecting on transport_mode alone, which also
+    matches UUID_B's rows. UUID_B keeps its extra category, and nothing outside it
+    satisfies that, so it is still unambiguous.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'transport_mode': 'cars', 'energy_carrier': None, VALUE_COLUMN: 1.0},
+            {
+                YEAR_COLUMN: 2020,
+                'uuid': UUID_B,
+                'transport_mode': 'cars',
+                'energy_carrier': 'electricity',
+                VALUE_COLUMN: 2.0,
+            },
+        ],
+        dims=['transport_mode', 'energy_carrier'],
+    )
+    assert dict(_uuids_from_binding(_binding(df))) == {
+        UUID_B: {'transport_mode': 'cars', 'energy_carrier': 'electricity'},
+    }
+
+
+def test_an_empty_selector_beside_any_other_is_dropped():
+    """The empty selector filters nothing, so it matches every other measure's rows too."""
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': None, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, 'energy_carrier': 'heat', VALUE_COLUMN: 2.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    assert dict(_uuids_from_binding(_binding(df))) == {UUID_B: {'energy_carrier': 'heat'}}
+
+
+def test_two_uuids_in_a_binding_with_no_dimensions_are_both_dropped():
+    """
+    An empty selector is as ambiguous as a shared one, and collides the same way.
+
+    Both measures would resolve to the same node, metric and (absent) categories, so the
+    resolver would hand them the identical output series.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_B, VALUE_COLUMN: 2.0},
+        ],
+        dims=[],
+    )
+    assert _uuids_from_binding(_binding(df)) == []
+
+
+def test_uuid_spanning_several_years_is_claimed_once():
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2021, 'uuid': UUID_A, VALUE_COLUMN: 2.0},
+            {YEAR_COLUMN: 2022, 'uuid': UUID_A, VALUE_COLUMN: 3.0},
+        ],
+        dims=[],
+    )
+    assert _uuids_from_binding(_binding(df)) == [(UUID_A, None)]
+
+
+def _instance_with_bindings(node_id: str, tag_sets: list[list[str]]) -> Any:
+    node = SimpleNamespace(input_dataset_instances=[_binding(None, tags) for tags in tag_sets])
+    return SimpleNamespace(context=SimpleNamespace(nodes={node_id: node}))
+
+
+def test_historical_binding_wins_over_goal_on_the_same_node():
+    """One dataset, one uuid column, a historical and a goal value column: take historical."""
+    instance = _instance_with_bindings('renovation', [['city_data', 'historical'], ['city_data', 'goal']])
+    values = [
+        NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=0),
+        NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=1),
+    ]
+
+    assert FrameworkConfig._prefer_historical_bindings(instance, values) == [values[0]]
+
+
+def test_untagged_binding_wins_over_goal():
+    instance = _instance_with_bindings('renovation', [['city_data'], ['city_data', 'goal']])
+    values = [
+        NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=0),
+        NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=1),
+    ]
+
+    assert FrameworkConfig._prefer_historical_bindings(instance, values) == [values[0]]
+
+
+def _instance_with_nodes_bindings(spec: dict[str, list[list[str]]], deltas: set[str] | None = None) -> Any:
+    """Return an instance whose nodes carry the given binding tag-sets, optionally delta-valued."""
+    deltas = deltas or set()
+    nodes = {
+        node_id: SimpleNamespace(
+            input_dataset_instances=[_binding(None, tags) for tags in tag_sets],
+            output_is_baseline_delta=node_id in deltas,
+        )
+        for node_id, tag_sets in spec.items()
+    }
+    return SimpleNamespace(context=SimpleNamespace(nodes=nodes))
+
+
+def test_tag_ranking_does_not_reach_across_nodes():
+    """
+    The tag tie-break settles which column of one dataset to read, nothing more.
+
+    An action binds a column as ``historical`` while the level node downstream binds the
+    same column untagged. Ranking them together lets the action win and the ``*_observed``
+    node never reaches the preference that exists for it -- and the action reports a
+    baseline delta, so the cell ends up blank.
+    """
+    instance = _instance_with_nodes_bindings({
+        'a31_renovation_improvements': [['city_data', 'historical']],
+        'old_building_renovation_rate_observed': [['city_data']],
+    })
+    action = NodeDimensionSelection(node_id='a31_renovation_improvements', dimensions=None, dataset_index=0)
+    observed = NodeDimensionSelection(node_id='old_building_renovation_rate_observed', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_historical_bindings(instance, [action, observed]) == [action, observed]
+
+
+def test_a_level_node_beats_a_delta_node():
+    """
+    A cell asks what the plan is, and a delta node answers how far it moves.
+
+    The node-id heuristics cannot separate these: neither ``new_building_shares`` nor
+    ``a32_new_building_improvements`` carries a suffix they recognise.
+    """
+    instance = _instance_with_nodes_bindings(
+        {'new_building_shares': [['city_data']], 'a32_new_building_improvements': [['city_data', 'historical']]},
+        deltas={'a32_new_building_improvements'},
+    )
+    level = NodeDimensionSelection(node_id='new_building_shares', dimensions=None, dataset_index=0)
+    delta = NodeDimensionSelection(node_id='a32_new_building_improvements', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_a_level_over_a_delta(instance, [level, delta]) == [level]
+
+
+def test_all_delta_candidates_are_left_for_the_resolver_to_withhold():
+    """Nothing to prefer, so the choice stands and the resolver declines to show a delta."""
+    instance = _instance_with_nodes_bindings({'a1': [['city_data']], 'a2': [['city_data']]}, deltas={'a1', 'a2'})
+    first = NodeDimensionSelection(node_id='a1', dimensions=None, dataset_index=0)
+    second = NodeDimensionSelection(node_id='a2', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_a_level_over_a_delta(instance, [first, second]) == [first, second]
+
+
+def test_legacy_selection_survives_alongside_a_goal_binding():
+    """A DatasetNode carries no binding to rank, so it must reach the node-id heuristics."""
+    instance = _instance_with_bindings('renovation', [['city_data', 'goal']])
+    legacy = NodeDimensionSelection(node_id='population_observed', dimensions=None)
+    binding = NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_historical_bindings(instance, [legacy, binding]) == [legacy, binding]
+
+
+def test_legacy_selection_survives_alongside_a_historical_binding():
+    """
+    A historical binding must not evict a legacy candidate.
+
+    Ranking a binding-less selection against a binding would silently resolve mixed
+    models -- a uuid still present on a DatasetNode *and* on a new city_data binding --
+    without the node-id heuristics getting a say.
+    """
+    instance = _instance_with_bindings('renovation', [['city_data', 'historical']])
+    legacy = NodeDimensionSelection(node_id='population_observed', dimensions=None)
+    binding = NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_historical_bindings(instance, [legacy, binding]) == [legacy, binding]
+
+
+def test_legacy_selection_survives_a_tie_between_bindings():
+    """The tag tiebreak narrows the bindings but must still leave the legacy candidate."""
+    instance = _instance_with_bindings('renovation', [['city_data', 'historical'], ['city_data', 'goal']])
+    legacy = NodeDimensionSelection(node_id='population_observed', dimensions=None)
+    historical = NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=0)
+    goal = NodeDimensionSelection(node_id='renovation', dimensions=None, dataset_index=1)
+
+    survivors = FrameworkConfig._prefer_historical_bindings(instance, [legacy, historical, goal])
+
+    assert survivors == [legacy, historical]
+
+
+def _real_binding(df: PathsDataFrame, tags: list[str]) -> FrameworkMeasureDVCDataset2:
+    """
+    Build a binding the node walk will accept, with its frame already in place.
+
+    The walk tests the concrete dataset type, so a stand-in object is skipped. Seeding
+    the memo means ``get_uuid_frame`` answers without reaching for DVC or the database.
+    """
+    ds = object.__new__(FrameworkMeasureDVCDataset2)
+    ds.id = 'nzc/buildings_stock_renovation'
+    ds.tags = tags
+    ds._uuid_frame = df
+    ds._uuid_frame_loaded = True
+    return ds
+
+
+def _node_with_metrics(bindings: list[Any], metrics: dict[str, str]) -> Any:
+    """Return a non-DatasetNode whose output_metrics map metric id to output column."""
+    return SimpleNamespace(
+        id='a31_renovation_improvements',
+        input_dataset_instances=bindings,
+        output_metrics={mid: SimpleNamespace(column_id=col) for mid, col in metrics.items()},
+    )
+
+
+def test_binding_tag_names_the_output_metric():
+    """
+    A multi-metric node renames Value to the metric column, so the binding must say which.
+
+    The config tags each binding with the metric id it feeds, alongside historical/goal.
+    Without this the resolver finds no Value column and blanks the cell.
+    """
+    df = _frame([{YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0}], dims=[])
+    node = _node_with_metrics(
+        [_real_binding(df, ['historical', 'renovation_rate', 'city_data'])],
+        {'renovation_rate': 'renovation_rate', 'renovation_shares': 'renovation_shares'},
+    )
+    ((_uuid, sel),) = FrameworkConfig()._get_node_dimension_selections('a31_renovation_improvements', node)
+
+    assert _uuid == UUID_A
+    assert sel.metric_col == 'renovation_rate'
+
+
+def test_single_metric_node_leaves_metric_col_unset():
+    """Nothing was renamed, so Value is the series and there is no column to record."""
+    df = _frame([{YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0}], dims=[])
+    node = _node_with_metrics([_real_binding(df, ['historical', 'city_data'])], {})
+    ((_uuid, sel),) = FrameworkConfig()._get_node_dimension_selections('population', node)
+
+    assert sel.metric_col is None
+
+
+def _points(df: PathsDataFrame, selection: NodeDimensionSelection) -> list[tuple[Any, Any]]:
+    pts = MeasureType._narrow_to_placeholders(df, selection, baseline_year=2019, last_year=2026, label='test measure')
+    return [(p.year, p.value) for p in pts]
+
+
+_BINDING_SEL = NodeDimensionSelection(node_id='n', dimensions=None, dataset_index=0)
+
+
+def test_years_outside_the_sheet_window_are_dropped():
+    df = _frame(
+        [{YEAR_COLUMN: y, 'uuid': UUID_A, VALUE_COLUMN: float(y)} for y in (2018, 2019, 2020, 2026, 2027)],
+        dims=[],
+    )
+    assert _points(df, _BINDING_SEL) == [(2020, 2020.0), (2026, 2026.0)]
+
+
+def test_null_values_from_a_sibling_metric_are_dropped():
+    """
+    A multi-metric node keeps rows where the other metrics have nothing to say.
+
+    After selecting one metric those read as null. They are not this measure's series,
+    and counting them would trip the one-row-per-year guard and blank a cell that has a
+    perfectly good value.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: None},
+            {YEAR_COLUMN: 2021, 'uuid': UUID_A, VALUE_COLUMN: 2.0},
+        ],
+        dims=[],
+    )
+    assert _points(df, _BINDING_SEL) == [(2020, 1.0), (2021, 2.0)]
+
+
+def test_genuinely_duplicated_years_yield_nothing():
+    """Two real values for one year means the selection failed; do not pick one."""
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 9.0},
+        ],
+        dims=[],
+    )
+    assert _points(df, _BINDING_SEL) == []
+
+
+def test_categories_narrow_to_one_series():
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'heat', VALUE_COLUMN: 9.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    sel = NodeDimensionSelection(node_id='n', dimensions={'energy_carrier': 'electricity'}, dataset_index=0)
+    assert _points(df, sel) == [(2020, 1.0)]
+
+
+_LEGACY_SEL = NodeDimensionSelection(node_id='n', dimensions=None, dataset_index=None)
+
+
+def test_legacy_path_keeps_emitting_duplicate_years():
+    """
+    The one-row-per-year guard is deliberately binding-only.
+
+    A DatasetNode wraps a single dataset, so its output was always taken as the measure's
+    series whatever shape it had. No NZC config reaches this branch any more -- the model
+    swap left none of those nodes -- so nothing but this test holds the behaviour still.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 9.0},
+        ],
+        dims=[],
+    )
+    assert _points(df, _LEGACY_SEL) == [(2020, 1.0), (2020, 9.0)]
+
+
+def test_legacy_path_drops_null_values():
+    """
+    Null filtering is shared, and this pins that it is safe to share.
+
+    A null placeholder is nothing the client can draw, and leaving one in could displace
+    a real value for that year, so dropping it is an improvement on the legacy path too --
+    but it is a behaviour change to code CADS would run, hence the test.
+    """
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: None},
+            {YEAR_COLUMN: 2021, 'uuid': UUID_A, VALUE_COLUMN: 2.0},
+        ],
+        dims=[],
+    )
+    assert _points(df, _LEGACY_SEL) == [(2021, 2.0)]
+
+
+def test_legacy_path_still_honours_categories_and_the_window():
+    df = _frame(
+        [
+            {YEAR_COLUMN: 2019, 'uuid': UUID_A, 'energy_carrier': 'heat', VALUE_COLUMN: 1.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'heat', VALUE_COLUMN: 2.0},
+            {YEAR_COLUMN: 2020, 'uuid': UUID_A, 'energy_carrier': 'electricity', VALUE_COLUMN: 3.0},
+        ],
+        dims=['energy_carrier'],
+    )
+    sel = NodeDimensionSelection(node_id='n', dimensions={'energy_carrier': 'heat'}, dataset_index=None)
+    assert _points(df, sel) == [(2020, 2.0)]
+
+
+def _instance_with_nodes(*nodes: Any) -> Any:
+    return SimpleNamespace(context=SimpleNamespace(nodes={n.id: n for n in nodes}))
+
+
+def _node(node_id: str, unit: str | None, dims: list[str], metrics: dict[str, str] | None = None) -> Any:
+    return SimpleNamespace(
+        id=node_id,
+        unit=unit_registry.parse_units(unit) if unit else None,
+        output_nodes=[],
+        output_dimensions=dict.fromkeys(dims),
+        output_metrics={mid: SimpleNamespace(column_id=col) for mid, col in (metrics or {}).items()},
+    )
+
+
+def _action(action_id: str, targets: list[Any]) -> Any:
+    """
+    Return a real ActionNode, so the isinstance check in the traversal holds.
+
+    ``output_nodes`` is a read-only property derived from the graph's edges, so a subclass
+    supplies the targets rather than a plain instance being mutated.
+    """
+    from nodes.actions.simple import GenericAction
+
+    class _StubAction(GenericAction):
+        @property
+        def output_nodes(self) -> list[Any]:  # type: ignore[override]
+            return list(targets)
+
+    action = object.__new__(_StubAction)
+    action.id = action_id
+    return action
+
+
+def _goal_chain(goal_unit: str = '%', target_unit: str = '%', dims: list[str] | None = None) -> tuple[Any, Any]:
+    """Return ``goal -> action -> trajectory``, the shape NZC uses."""
+    dims = dims if dims is not None else ['transport_mode']
+    goal = _node('utilisation_goal', goal_unit, dims)
+    trajectory = _node('utilisation', target_unit, dims)
+    goal.output_nodes = [_action('a21_optimised_logistics', [trajectory])]
+    return goal, trajectory
+
+
+def test_a_goal_node_defers_to_the_trajectory_the_action_emits():
+    """
+    Follow the graph, not the name.
+
+    The goal holds only the target end; the action combines it with history and emits the
+    whole series, so the relationship is the graph edge.
+    """
+    goal, trajectory = _goal_chain()
+    instance = _instance_with_nodes(goal, trajectory)
+    sel = NodeDimensionSelection(node_id='utilisation_goal', dimensions={'transport_mode': 'light_trucks'}, dataset_index=0)
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel).node_id == 'utilisation'
+
+
+def test_a_node_feeding_no_action_is_left_alone():
+    """Nothing better to point at, so the measure keeps its node and shows nothing."""
+    lone = _node('fossil_electricity_goal', '%', [])
+    instance = _instance_with_nodes(lone)
+    sel = NodeDimensionSelection(node_id='fossil_electricity_goal', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel).node_id == 'fossil_electricity_goal'
+
+
+def test_the_action_output_measuring_the_same_quantity_is_chosen():
+    """
+    Pick the output measuring the goal's own quantity.
+
+    An action feeds several nodes: ``a21_optimised_logistics`` emits a utilisation
+    percentage and vehicle kilometres, and only the former is this measure's quantity.
+    """
+    goal = _node('utilisation_goal', '%', ['transport_mode'])
+    trajectory = _node('utilisation', '%', ['transport_mode'])
+    other = _node('freight_transport_vehicle_kilometres', 'Mvehicle_km/a', ['transport_mode'])
+    goal.output_nodes = [_action('a21_optimised_logistics', [trajectory, other])]
+    instance = _instance_with_nodes(goal, trajectory, other)
+    sel = NodeDimensionSelection(node_id='utilisation_goal', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel).node_id == 'utilisation'
+
+
+def test_an_ambiguous_action_output_is_left_alone():
+    """Two candidates of the same quantity, so the graph does not answer; do not guess."""
+    goal = _node('utilisation_goal', '%', ['transport_mode'])
+    trajectory = _node('utilisation', '%', ['transport_mode'])
+    twin = _node('utilisation_twin', '%', ['transport_mode'])
+    goal.output_nodes = [_action('a21_optimised_logistics', [trajectory, twin])]
+    instance = _instance_with_nodes(goal, trajectory, twin)
+    sel = NodeDimensionSelection(node_id='utilisation_goal', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel).node_id == 'utilisation_goal'
+
+
+def test_a_target_that_cannot_serve_the_selection_is_not_used():
+    """The redirect must not hand the resolver a node it cannot filter the same way."""
+    goal, trajectory = _goal_chain(dims=['transport_mode'])
+    trajectory.output_dimensions = dict.fromkeys(['other_dim'])
+    instance = _instance_with_nodes(goal, trajectory)
+    sel = NodeDimensionSelection(node_id='utilisation_goal', dimensions={'transport_mode': 'light_trucks'}, dataset_index=0)
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel).node_id == 'utilisation_goal'
+
+
+def test_a_target_without_the_chosen_metric_is_not_used():
+    goal, trajectory = _goal_chain(dims=[])
+    trajectory.output_metrics = {'other': SimpleNamespace(column_id='other')}
+    instance = _instance_with_nodes(goal, trajectory)
+    sel = NodeDimensionSelection(node_id='utilisation_goal', dimensions=None, dataset_index=0, metric_col='renovation_rate')
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel).node_id == 'utilisation_goal'
+
+
+def test_an_ordinary_node_is_untouched():
+    plain = _node('population', 'cap', [])
+    instance = _instance_with_nodes(plain)
+    sel = NodeDimensionSelection(node_id='population', dimensions=None, dataset_index=0)
+
+    assert FrameworkConfig._prefer_the_full_trajectory(instance, sel) is sel
+
+
+def test_delta_producing_classes_declare_it():
+    """
+    The resolver withholds these values, and relies on the class to say so.
+
+    Both end on ``col - pl.first(col)``. Checking the declaration rather than the class
+    keeps the arithmetic and the claim about it together: a producer that starts or stops
+    subtracting the baseline updates one line, and no consumer has to be edited to match.
+    """
+    from nodes.actions.gpc import DatasetDifferenceAction2, SCurveAction as GPCSCurveAction
+    from nodes.actions.linear import DatasetDifferenceAction, DatasetReduceAction, DatasetReduceAction2
+    from nodes.actions.simple import SCurveAction
+
+    # Each subtracts a baseline or last-historical anchor before returning.
+    assert DatasetReduceAction.output_is_baseline_delta
+    assert DatasetReduceAction2.output_is_baseline_delta
+    assert DatasetDifferenceAction.output_is_baseline_delta
+    assert DatasetDifferenceAction2.output_is_baseline_delta
+    assert SCurveAction.output_is_baseline_delta
+    assert GPCSCurveAction.output_is_baseline_delta
+
+
+def test_levels_are_the_default():
+    """
+    The claim is about the arithmetic, not about being an action.
+
+    GenericAction returns its own quantity, and the one NZC measure sitting on one is a
+    reduction percentage that reads correctly as it stands.
+    """
+    from nodes.actions.simple import GenericAction
+    from nodes.generic import GenericNode
+    from nodes.node import Node
+
+    assert not Node.output_is_baseline_delta
+    assert not GenericNode.output_is_baseline_delta
+    assert not GenericAction.output_is_baseline_delta
+
+
+def _exploding_binding(tags: list[str]) -> FrameworkMeasureDVCDataset2:
+    """Return a binding whose source cannot be read, as a missing dataset would be."""
+    from nodes.exceptions import NodeError
+
+    ds = object.__new__(FrameworkMeasureDVCDataset2)
+    ds.id = 'nzc/vanished'
+    ds.tags = tags
+
+    def boom() -> Any:
+        raise NodeError(SimpleNamespace(id='n'), 'dataset is gone')  # type: ignore[arg-type]
+
+    ds.get_uuid_frame = boom  # type: ignore[method-assign]
+    return ds
+
+
+def test_one_unreadable_binding_does_not_blank_the_others():
+    """
+    The mapping is built once for the whole config and every measure waits on it.
+
+    An exception escaping here fails correspondingNode and placeholderDataPoints for every
+    measure on the tab -- and being a cached_property it is not cached either, so each
+    measure retries the same broken load.
+    """
+    good = _frame([{YEAR_COLUMN: 2020, 'uuid': UUID_A, VALUE_COLUMN: 1.0}], dims=[])
+    node = _node_with_metrics(
+        [_exploding_binding(['city_data']), _real_binding(good, ['city_data'])],
+        {},
+    )
+    selections = FrameworkConfig()._get_node_dimension_selections('population', node)
+
+    assert [u for u, _ in selections] == [UUID_A]
+
+
+def test_an_unreadable_binding_claims_nothing():
+    node = _node_with_metrics([_exploding_binding(['city_data'])], {})
+
+    assert FrameworkConfig()._get_node_dimension_selections('population', node) == []

--- a/nodes/actions/gpc.py
+++ b/nodes/actions/gpc.py
@@ -424,6 +424,9 @@ class SCurveAction(DatasetAction):  # TODO Remove after nzc.yaml is using the ne
     )
     allowed_parameters = DatasetAction2.allowed_parameters
 
+    # The s-curve is emitted net of the baseline value it starts from.
+    output_is_baseline_delta: ClassVar[bool] = True
+
     no_effect_value = 0.0
 
     def newton_raphson_estimator(self, y1, y2, x1, x2, a, max_iter=100, tol=1e-6):
@@ -548,6 +551,9 @@ class DatasetDifferenceAction2(DatasetAction):
     reductions), in which case the input will be treated as
     a multiplier.
     """)
+
+    # Output is the difference to the last historical year, not the level itself.
+    output_is_baseline_delta: ClassVar[bool] = True
 
     allowed_parameters: ClassVar[list[Parameter[Any]]] = [
         *DatasetAction.allowed_parameters,

--- a/nodes/actions/linear.py
+++ b/nodes/actions/linear.py
@@ -158,6 +158,10 @@ class DatasetReduceAction(ActionNode):
       single column is used as-is (e.g. a shared multiplier with ``relative_goal: true``).
     """
 
+    # The pipeline ends on `col - pl.first(col)`, so what leaves here is movement from
+    # the baseline year, not a level.
+    output_is_baseline_delta: ClassVar[bool] = True
+
     allowed_parameters: ClassVar[list[Parameter[Any]]] = [
         BoolParameter(local_id='relative_goal'),
     ]
@@ -361,6 +365,10 @@ class DatasetReduceAction2(ActionNode):
       If the source has a column named after the metric it is extracted; otherwise the
       single column is used as-is (e.g. a shared multiplier with ``relative_goal: true``).
     """
+
+    # The pipeline ends on `col - pl.first(col)`, so what leaves here is movement from
+    # the baseline year, not a level.
+    output_is_baseline_delta: ClassVar[bool] = True
 
     allowed_parameters: ClassVar[list[Parameter[Any]]] = [
         *ActionNode.allowed_parameters,
@@ -575,6 +583,9 @@ class DatasetDifferenceAction(ActionNode):  # FIXME Merge with DatasetReduceActi
     reductions), in which case the input will be treated as
     a multiplier.
     """)
+
+    # Output is the difference to the baseline series, not the level itself.
+    output_is_baseline_delta: ClassVar[bool] = True
 
     allowed_parameters: ClassVar[list[Parameter]] = [
         BoolParameter(local_id='relative_goal'),

--- a/nodes/actions/simple.py
+++ b/nodes/actions/simple.py
@@ -63,6 +63,10 @@ class SCurveAction(GenericAction):
         + 'data and one input dataset with max_impact / max_year rows.'
     )
     allowed_parameters = [*GenericAction.allowed_parameters]
+
+    # The s-curve is emitted net of the baseline value it starts from.
+    output_is_baseline_delta: ClassVar[bool] = True
+
     no_effect_value = 0.0
 
     def _newton_raphson_estimator(

--- a/nodes/node.py
+++ b/nodes/node.py
@@ -352,6 +352,15 @@ class Node:
     class (rather than switched on concrete types in the loader) so the dataset
     semantics live with the node class that defines them."""
 
+    output_is_baseline_delta: ClassVar[bool] = False
+    """Whether this class's output is change from the baseline year rather than a level.
+
+    Declared by the class (rather than switched on concrete types in a consumer) so the
+    arithmetic and the claim about it cannot drift apart. A consumer that reads the output
+    as an absolute figure has to know the difference: a delta presented as a level is wrong
+    by the whole baseline. See ``MeasureType._get_placeholder_df``, which withholds a value
+    it cannot present honestly."""
+
     input_port_declarations: ClassVar[tuple[InputPortDeclaration, ...]] = ()
     output_port_declarations: ClassVar[tuple[OutputPortDeclaration, ...]] = ()
     """Semantic role declarations shared by future get_input() and shape_rules()."""


### PR DESCRIPTION
Every cell a city has not filled in should show that year's planned value in
grey. Those hints have been missing since late June.

## What broke

The values are `Measure.placeholderDataPoints`, resolved by matching each
MeasureTemplate UUID to a node in the instance graph. That lookup recognised
nodes by concrete class:

    # Intentionally test for concrete type, filter out subclasses
    if type(node) is not DatasetNode:
        continue

f2d6be20 swapped the NZC model for the lucia-derived one, which carries its city
data on tagged input dataset bindings instead: `configs/nzc.yaml` went from six
live `gpc.DatasetNode` entries to none, and gained 127 `city_data` tags. Nothing
matched, so every measure resolved to a null `correspondingNode` and an empty
`placeholderDataPoints`, which the UI renders as a blank cell with no error.

This was an incomplete migration rather than config drift.
`get_measure_datapoint_years()` moved to the tagged-binding world in ff1ed6b1,
eight days later; this call site was left behind. It was the last exact-type
`DatasetNode` check in the repo.

## What this does

Keeps the `DatasetNode` branch and adds a binding branch beside it, following
the shape ff1ed6b1 established.

Values still come from `node.get_output_pl()`, as they always did. The plan
value for a given year is not written down anywhere -- the city-data datasets
carry a single authored row per measure, at the baseline year, and the
trajectory across the years the sheet asks about is what the model computes from
it. The binding is how a measure is *found*, not where its values live.

That makes categories the only handle on a measure, since node output carries no
UUID, so a UUID they cannot pin to one series is left unmapped rather than
answered with someone else's numbers:

- a UUID spread over several categories has no single series;
- a UUID whose selector is *contained* in another's is the broader filter --
  `{transport_mode: cars}` sweeps up `{transport_mode: cars, energy_carrier:
  electricity}` -- so it goes, while the narrower one survives. Equality is the
  symmetric case; the empty selector, contained in everything, is fine alone in
  a binding and ambiguous beside anything else.

Null categories are stripped first: they mean the column does not apply, and
filtering output for a null matches nothing.

Several bindings can claim one UUID, since a dataset commonly holds a single
UUID column beside historical and goal value columns. The node-id heuristics
cannot separate bindings on one node, so the tie breaks on tags first,
preferring the historical series -- placeholders are only ever asked for years
at or before today. That ranking runs *per node*: it settles which column of one
dataset to read, and nothing more. Reaching across nodes it would decide badly,
because an action binds a column as `historical` while the level node downstream
of it binds the same column untagged -- the action would win a preference meant
for the `*_observed` node, and then be withheld as a delta, leaving the cell
blank.

Across nodes the tie breaks on what a candidate can report instead. A cell asks
what the plan is for a year; a node declaring `output_is_baseline_delta` answers
how far the plan moves, so a candidate that can report a level wins. The node-id
heuristics cannot see that difference -- neither `new_building_shares` nor
`a32_new_building_improvements` carries a suffix they recognise. A legacy
selection has no binding to rank and must reach those heuristics intact.

A measure can also end up on a goal node, which carries only the target end of a
series and so begins after the window closes. That happens when the dataset's
historical column is null for it, leaving the goal binding as the only claimant
-- not because the goal series is what the cell wants.

Which node carries the whole series is read off the graph rather than off the
node's name: a goal feeds an action, and the action combines it with the
historical series and emits the trajectory, so the selection follows
`goal -> action -> output`.

    average_truck_utilisation_goal -> a21_optimised_logistics -> average_truck_utilisation
    waste_recycling_shares_goal    -> a51_increase_waste_recycling -> waste_recycling_shares
    electricity_shares_goal        -> a41_replace_fossil_electricity -> electricity_shares

An action commonly feeds several nodes -- `a21_optimised_logistics` emits both a
utilisation percentage and vehicle kilometres -- so the target has to measure the
same quantity as the goal and be able to serve the selection's categories and
metric. Where the graph does not answer unambiguously nothing moves.

Reading a `_goal` suffix instead would let a rename change the numbers a city
sees, and would claim the relationship for any node merely ending that way.

A multi-metric node renames `Value` to the metric column, so the binding records
which metric it feeds -- the config already tags it with the metric id -- and
the resolver reads that column under the expected name. Such a node also
outer-joins metrics spanning different dimensions and keeps the rows where the
others have nothing to say, so null values are dropped before anything counts
rows per year.

Units convert where compatible, since a node in kg against a template in t is a
thousand-times-wrong number. Where they are not convertible the annotations
disagree rather than the magnitudes -- a rate node in `%/a` against a template
in `%` -- so the value passes through as the legacy path always did rather than
blanking the cell over a units quibble.

## Verification

Measured against real data on `budapest-cap-2030`: of 199 measures, 159 map and
155 resolve to a full 2020-2026 series, none with duplicate years. 21 of those
are withheld as deltas (see below), so 134 reach the client. Before this change
the mapping was empty and no measure showed anything.

Sampling four cities gives identical counts, as expected from a shared config.

The values hold together as a set: waste treatment shares sum to 100% within
each waste type (paper 18.18 landfill + 55.91 incinerated + 25.91 recycled) and
trend the right way -- a property that would break if the wrong node or a
crossed series had been picked.

The lookup had no test coverage, which is why this went unnoticed for weeks. It
now has 68 tests covering the mapping rules and the resolver's frame-shaping.

## Deltas are withheld, pending an answer

For action-node measures the model stores cumulative change from the baseline
year, not a level: `DatasetReduceAction` and `DatasetReduceAction2` both end on
`col - pl.first(col)`. A "share of heating from fossil fuels" cell would show
`-3.7` -- the planned *reduction* -- where a city expects the planned share.

The resolver has always read node output this way, so this is not introduced
here; the model swap changed which measures travel this route. But a grey number
that looks authoritative and means something else is worse than a blank one: it
can lead a city to enter the wrong figure, or to doubt correct data.

Those measures were blank before this branch, so the resolver withholds them and
nothing about them changes for a city while the question is open. That keeps the
question off the critical path: 134 measures are restored and none is a delta.
It affects 21 of the 155 resolved measures -- those left with no candidate able
to report a level at all.

Which nodes those are is the node's own claim, not a list kept in the resolver.
`Node.output_is_baseline_delta` defaults to False, and every class that subtracts
a baseline or last-historical anchor sets it beside the arithmetic that earns it,
following `uses_framework_measure_data`:

    linear.DatasetReduceAction        col - pl.first(col)
    linear.DatasetReduceAction2       col - pl.first(col)
    linear.DatasetDifferenceAction    subtract_cols against the baseline series
    gpc.DatasetDifferenceAction2      col - pl.first(col)
    gpc.SCurveAction                  subtract_cols against the starting value
    simple.SCurveAction               subtract_cols against the starting value

A producer that starts or stops subtracting the baseline changes one line next to
the code that does it, and no consumer has to be edited to keep up -- a type
switch in the resolver would have gone stale silently, presenting a delta as a
level. Only the two DatasetReduce classes back a measure on
`budapest-cap-2030` today, so the other four cost nothing there; they were
misclassified all the same, and a config change is all it would take to expose
one.

The claim is about the arithmetic, not about being an action: `GenericAction`
returns its own quantity, and the one NZC measure on one is a reduction
percentage that reads correctly. The withholding is marked TEMPORARY. Once the
model owner confirms what such a cell should show, either delete that block to
restore the 21 measures as they are, or convert the delta into a level there.

## One unreadable source does not blank the tab

The mapping is built once for the whole framework config and every measure waits
on it, and `_find_corresponding_node` runs outside the resolver's
`NodeComputationError` handler. So an exception raised while scanning one binding
-- a missing DVC dataset, a column removed out from under it -- would fail
`correspondingNode` and `placeholderDataPoints` for every measure on the tab, and
since the mapping is a `cached_property`, a raising call caches nothing and each
following measure retries the same broken load.

Each source is read through `_claimed_uuids()`, which treats a failure as "claims
nothing", logs it and reports it to Sentry. A broken binding costs its own
measures and no others. The legacy `DatasetNode` branch reads through it too;
`get_filtered_dataset_df` raises `NodeError` just as readily.

The catch there is deliberately broad. What can come out of a DVC load and a
transform pipeline is not a closed set, and the point is that nothing escaping
one source can blank the whole tab; `capture_exception` keeps it visible rather
than silent.

## Known gaps, not blocking

- 40 measures are unmapped. This mixes measures with no `city_data` binding at
  all (several look like manual entry by design, e.g. City Area), cross-node
  ambiguities, and selector collisions. It needs itemising so someone can say
  which are genuine gaps.
- One measure maps to `fossil_electricity_goal`, which has no plain sibling to
  defer to, and still shows nothing. A config-shape question rather than a code
  one.
- 21 measures resolve correctly but are withheld pending the deltas question.
- Verified through the resolver, not through the browser. The GraphQL round-trip
  and the grey rendering itself have not been exercised.

## Note on the legacy branch

The placeholder feature is NZC-only: CADS has no sections, measure templates or
measures in any deployment, and every NZC instance loads the `configs/nzc.yaml`
that the swap left without a live `gpc.DatasetNode`. The legacy branch is
therefore unreachable, and is pinned by tests rather than by data. Several
complications here exist only to serve it -- the legacy passthrough in the tie
break, the binding-only duplicate-year guard, the binding-only unit conversion
-- so removing it would be a worthwhile follow-up, kept off this branch
deliberately.

