### PR TITLE
Fix inverse unit bug

### DIFF
--- a/src/nodes/constraints/solver.py
+++ b/src/nodes/constraints/solver.py
@@ -45,6 +45,7 @@ from nodes.constraints.rules import (
     ProductShapeRule,
     SameShapeRule,
 )
+from nodes.constraints.tags import tag_operation_is_opaque
 from nodes.constraints.values import (
     BindingValue,
     ConstraintConflict,
@@ -75,52 +76,6 @@ if TYPE_CHECKING:
     from nodes.instance_graph import InstanceGraph
 
 MAX_SOLVER_SWEEPS = 100
-
-NEUTRAL_TAG_OPERATIONS = frozenset({
-    'abs',
-    'absolute',
-    'add_missing_years',
-    'arithmetic_inverse',
-    'cumulative',
-    'drop_infs',
-    'drop_nans',
-    'drop_zeros',
-    'empty_to_zero',
-    'extend_all',
-    'extend_both_ways',
-    'extend_forecast_values',
-    'extend_to_history',
-    'extend_values',
-    'extrapolate',
-    'fill_metrics_nan_null_zero',
-    'forecast_only',
-    'ignore_content',
-    'inventory_only',
-    'linear_interpolate',
-    'make_nonnegative',
-    'make_nonpositive',
-    'minus',
-    'observed_only_extend_all',
-    'round_to_five',
-    'truncate_before_start',
-    'truncate_beyond_end',
-    'use_observations',
-})
-"""
-Registered tag operations that provably preserve dimensions, categories,
-unit, and quantity. Any *other* registered operation (``complement``,
-``geometric_inverse``, ``ratio_to_last_historical_value``, …) reshapes or
-re-units the value, so the binding carrying it goes opaque. A tag that is
-not a registered operation at all selects behavior instead of transforming
-the frame and stays neutral.
-"""
-
-
-def _tag_is_opaque(tag: str) -> bool:
-    from common.polars_ext import PathsExt
-
-    return tag in PathsExt._OPERATION_METHODS and tag not in NEUTRAL_TAG_OPERATIONS
-
 
 # --- Resolved transformation steps -------------------------------------------
 
@@ -387,14 +342,14 @@ def _resolve_binding_steps(  # noqa: C901, PLR0912
                     )
                 )
             case TagOperationOp():
-                if _tag_is_opaque(op.tag):
+                if tag_operation_is_opaque(op.tag):
                     steps.append(OpaqueStep(reason=f'tag operation {op.tag!r}', index=index))
             case _:
                 # Temporal, forecast, raw-column and marker ops do not touch
                 # dimensions, categories, unit, or quantity.
                 continue
     for tag in binding.tags:
-        if _tag_is_opaque(tag):
+        if tag_operation_is_opaque(tag):
             steps.append(OpaqueStep(reason=f'tag operation {tag!r}', index=len(binding.transformations)))
             break
     return tuple(steps)

--- a/src/nodes/constraints/tags.py
+++ b/src/nodes/constraints/tags.py
@@ -1,0 +1,89 @@
+"""
+How a binding's tag operations bear on the shapes a constraint can state.
+
+Shared vocabulary rather than solver-internal detail, because node classes
+need it too: ``Node.shape_rules()`` is compiled from *ports*, while a tag
+operation is authored on a *binding*, so a class that wants to state the
+algebra of its inputs has to read the tags back off the bindings and decide
+what it can still honestly claim.
+
+Three cases, in the order a caller should test them:
+
+* **neutral** — the operation provably preserves dimensions, categories,
+  unit and quantity, so it changes nothing a rule says;
+* **inverting** — the operation's unit effect is exactly reciprocal, which
+  ``ProductShapeRule.inverse_inputs`` states precisely;
+* **opaque** — anything else registered: the value is re-united or reshaped
+  in a way no rule kind can express, so the constraint must be dropped
+  rather than guessed at.
+
+A tag that is not a registered dataframe operation at all selects behavior
+(``non_additive``, a formula variable name, a city-specific selector) rather
+than transforming the frame, and stays neutral.
+"""
+
+NEUTRAL_TAG_OPERATIONS = frozenset({
+    'abs',
+    'absolute',
+    'add_missing_years',
+    'arithmetic_inverse',
+    'cumulative',
+    'drop_infs',
+    'drop_nans',
+    'drop_zeros',
+    'empty_to_zero',
+    'extend_all',
+    'extend_both_ways',
+    'extend_forecast_values',
+    'extend_to_history',
+    'extend_values',
+    'extrapolate',
+    'fill_metrics_nan_null_zero',
+    'forecast_only',
+    'ignore_content',
+    'inventory_only',
+    'linear_interpolate',
+    'make_nonnegative',
+    'make_nonpositive',
+    'minus',
+    'observed_only_extend_all',
+    'round_to_five',
+    'truncate_before_start',
+    'truncate_beyond_end',
+    'use_observations',
+})
+"""
+Registered tag operations that provably preserve dimensions, categories,
+unit, and quantity. Any *other* registered operation (``complement``,
+``ratio_to_last_historical_value``, …) reshapes or re-units the value, so
+the binding carrying it goes opaque unless it is listed as inverting below.
+"""
+
+INVERTING_TAG_OPERATIONS = frozenset({
+    'geometric_inverse',
+})
+"""
+Registered tag operations whose effect on a unit is exactly reciprocal.
+
+These are opaque to anything that can only pass a unit through, but a
+product *can* state them: the tagged operand divides the product instead of
+multiplying it. Dimensions and categories are untouched — division does not
+remove a dimension — so a product rule remains fully expressible.
+"""
+
+
+def tag_operation_is_registered(tag: str) -> bool:
+    """Whether the tag names a dataframe operation at all, as opposed to selecting behavior."""
+    from common.polars_ext import PathsExt
+
+    return tag in PathsExt._OPERATION_METHODS
+
+
+def tag_operation_is_opaque(tag: str) -> bool:
+    """Whether the tag transforms a value in a way no shape rule can state."""
+    return tag_operation_is_registered(tag) and tag not in NEUTRAL_TAG_OPERATIONS
+
+
+def tag_operation_inverts(tag: str) -> bool:
+    """Whether the tag's unit effect is reciprocal, i.e. expressible as a product's inverse operand."""
+    return tag in INVERTING_TAG_OPERATIONS and tag_operation_is_registered(tag)

--- a/src/nodes/instance_parser.py
+++ b/src/nodes/instance_parser.py
@@ -1094,7 +1094,9 @@ class InstanceConfigParser:
                             fallback_id,
                         ),
                         identifier=identifier,
-                        unit=metric.unit if metric is not None else ds_def.unit,
+                        # An authored unit outranks the node's own output metric; see the
+                        # mirror in `spec_export._dataset_input_port_for_column`.
+                        unit=ds_def.unit if ds_def.unit is not None else (metric.unit if metric is not None else None),
                         quantity=metric.quantity if metric is not None else None,
                     )
                 )

--- a/src/nodes/simple.py
+++ b/src/nodes/simple.py
@@ -13,7 +13,9 @@ from common import polars as ppl
 from nodes.calc import convert_to_co2e, extend_last_historical_value_pl
 from nodes.constraints.port_roles import PortRoleInferenceResult
 from nodes.constraints.rules import AnyShapeRule, MissingPortRoleError, ProductShapeRule, SameShapeRule
+from nodes.constraints.tags import tag_operation_inverts, tag_operation_is_opaque
 from nodes.defs.port_def import InputPort, InputPortDeclaration, InputPortDef, OutputPortDeclaration
+from nodes.defs.transform_def import TagOperationOp
 from nodes.units import Quantity
 from params.param import BoolParameter, NumberParameter, StringParameter
 
@@ -54,6 +56,76 @@ EMISSION_UNIT = 'kg'
 
 def _runtime_port_id(node_id: str, index: int) -> UUID:
     return uuid5(NAMESPACE_URL, f'kausal-paths:{node_id}:pipeline-input:{index}')
+
+
+def _binding_tags(meta: NodeMeta, port_id: UUID) -> list[set[str]]:
+    """
+    Tags carried by each binding on one input port, one set per delivery.
+
+    A tag reaches a binding either as an authored tag or, once the binding has a
+    pipeline, as a ``TagOperationOp`` in it; a dataset port ends up with both.
+    Reading only one of the two would miss the operation on half the bindings.
+    """
+    tags: list[set[str]] = []
+    for binding in meta.bindings_for_port(port_id):
+        binding_tags = set(binding.tags)
+        binding_tags.update(op.tag for op in binding.transformations if isinstance(op, TagOperationOp))
+        tags.append(binding_tags)
+    return tags
+
+
+def _partition_product_operands(meta: NodeMeta, factor_ports: Sequence[UUID]) -> tuple[tuple[UUID, ...], tuple[UUID, ...]] | None:
+    """
+    Split factor ports into the direct and the inverse operands of a product.
+
+    ``geometric_inverse`` is authored on a *binding* while the product rule is
+    compiled from *ports*, so the tag has to be read back off the bindings here.
+    A port whose deliveries are all inverted divides the product rather than
+    multiplying it, which ``ProductShapeRule.inverse_inputs`` states exactly.
+
+    ``None`` means the algebra is not expressible and the caller should state no
+    rule at all: a port mixing inverted with direct deliveries has no single unit
+    contribution, and any other opaque tag operation re-units its factor beyond
+    what a product can say. Declining beats guessing — an unstated constraint is
+    merely incomplete, while a wrong one is a false conflict against the node's
+    own declared output.
+    """
+    direct: list[UUID] = []
+    inverse: list[UUID] = []
+    for port_id in factor_ports:
+        delivery_tags = _binding_tags(meta, port_id)
+        if any(tag_operation_is_opaque(tag) and not tag_operation_inverts(tag) for tags in delivery_tags for tag in tags):
+            return None
+        inverted = [any(tag_operation_inverts(tag) for tag in tags) for tags in delivery_tags]
+        if any(inverted) and not all(inverted):
+            return None
+        (inverse if any(inverted) else direct).append(port_id)
+    return tuple(direct), tuple(inverse)
+
+
+_RATIO_PARAM_IDS = ('reference_category', 'share_dimension')
+"""Params that divide a node's own sum by a slice of itself, collapsing its unit."""
+
+
+def _normalizes_to_ratio(meta: NodeMeta) -> bool:
+    """
+    Whether this node's params turn its sum into a dimensionless ratio.
+
+    ``reference_category`` divides every category by a reference one
+    (``SimpleNode.scale_by_reference_category``) and ``share_dimension``
+    converts values to shares over a dimension (``SimpleNode.get_shares``).
+    Both divide the sum by a slice of itself, so the output is dimensionless
+    however the inputs are united, and the plain "output shares the inputs'
+    shape" rule would contradict the node's own declaration.
+    """
+    return any(
+        param.local_id in _RATIO_PARAM_IDS and getattr(param, 'value', None) not in (None, '') for param in meta.spec.params
+    )
+
+
+def _ratio_total_value_id(node_uuid: UUID) -> UUID:
+    """Identity of the intermediate holding the sum, before it is divided by its own slice."""
+    return uuid5(node_uuid, 'kausal-paths:additive-ratio-total')
 
 
 def additive_multiplicity_hint(node_class: type[Node], edge: Edge | None) -> InputPortMultiplicityHint:
@@ -249,6 +321,19 @@ afterwards instead, replacing it wherever the tagged node has a value and leavin
         inputs = meta.input_port_ids_for_roles('additive', 'impute')
         if not inputs:
             return ()
+        if _normalizes_to_ratio(meta):
+            # The inputs still add together, so they share a shape with each
+            # other — but with the *sum*, not with the output, which is that
+            # sum divided by a slice of itself. Stating the division as a
+            # product of the sum over the sum gets both halves right: the unit
+            # cancels to dimensionless, and the dimensions survive it, because
+            # dividing by a reference category or normalizing to shares
+            # reindexes nothing.
+            total = _ratio_total_value_id(meta.id)
+            return (
+                SameShapeRule(inputs=inputs, output=total),
+                ProductShapeRule(inputs=(total,), inverse_inputs=(total,), output=output.id),
+            )
         return (SameShapeRule(inputs=inputs, output=output.id),)
 
     @classmethod
@@ -1085,7 +1170,10 @@ class MultiplicativeNode(SimpleNode, PipelineCompatibleNode):
         rules: list[AnyShapeRule] = []
         factors = meta.input_port_ids_for_roles('factors')
         if factors:
-            rules.append(ProductShapeRule(inputs=factors, output=output.id))
+            operands = _partition_product_operands(meta, factors)
+            if operands is not None:
+                direct, inverse = operands
+                rules.append(ProductShapeRule(inputs=direct, inverse_inputs=inverse, output=output.id))
         same_shaped = meta.input_port_ids_for_roles('additive', 'impute')
         if same_shaped:
             rules.append(SameShapeRule(inputs=same_shaped, output=output.id))
@@ -1365,7 +1453,10 @@ afterwards, replacing it wherever the tagged input has a value.""")
         rules: list[AnyShapeRule] = []
         factors = meta.input_port_ids_for_roles('factors')
         if factors:
-            rules.append(ProductShapeRule(inputs=factors, output=output.id))
+            operands = _partition_product_operands(meta, factors)
+            if operands is not None:
+                direct, inverse = operands
+                rules.append(ProductShapeRule(inputs=direct, inverse_inputs=inverse, output=output.id))
         same_shaped = meta.input_port_ids_for_roles('additive', 'impute')
         if same_shaped:
             rules.append(SameShapeRule(inputs=same_shaped, output=output.id))

--- a/src/nodes/spec_export.py
+++ b/src/nodes/spec_export.py
@@ -476,10 +476,18 @@ def _dataset_input_port_for_column(
     column: str,
 ) -> InputPortDef:
     metric = _metric_for_column(node, column)
+    declared_unit = getattr(dataset, 'unit', None)
     return InputPortDef(
         id=_dataset_port_id(node, dataset_index, column),
         identifier=_port_identifier_for_column(column),
-        unit=metric.unit if metric is not None else getattr(dataset, 'unit', None),
+        # An authored unit on the input dataset outranks the node's own output
+        # metric, because it is the one the port actually receives: it compiles
+        # to the pipeline's closing `ensure_unit`, so the value arrives in it.
+        # Falling back to the node's metric is a guess that only holds for a
+        # node whose dataset input is in its own output unit; on a formula node
+        # a dataset is one term, united independently of the formula's result.
+        # See the mirror in `instance_parser._build_dataset_input_ports`.
+        unit=declared_unit if declared_unit is not None else (metric.unit if metric is not None else None),
         quantity=metric.quantity if metric is not None else None,
     )
 

--- a/src/nodes/tests/test_constraint_solver.py
+++ b/src/nodes/tests/test_constraint_solver.py
@@ -23,6 +23,7 @@ from nodes.instance_serialization import (
 )
 from nodes.node import Node
 from nodes.units import unit_registry
+from params.param import StringParameter
 
 pytestmark = pytest.mark.django_db
 
@@ -587,3 +588,142 @@ def test_quantity_mismatch_on_same_shape_rule() -> None:
     result = graph.solve_constraints()
     conflict = next(c for c in result.conflicts if c.code == 'quantity_mismatch')
     assert all(origin.kind == 'declaration' for origin in conflict.origins)
+
+
+# --- Unit-changing semantics the rules have to state ------------------------------------
+
+
+def _tagged_edge(source: NodeSnapshot, source_port: UUID, target: NodeSnapshot, target_port: UUID, tags: list[str]):
+    edge = _edge(source, source_port, target, target_port)
+    return edge.model_copy(update={'tags': tags})
+
+
+def test_geometric_inverse_factor_divides_the_product() -> None:
+    """A ``geometric_inverse`` factor is a divisor, so the product's unit is a quotient."""
+    numerator_port = InputPortDef(id=uuid4(), identifier='pkm', unit=_unit('Mpkm/a'))
+    divisor_port = InputPortDef(id=uuid4(), identifier='population', unit=_unit('cap'))
+    target, output_id = _multiplicative_target([numerator_port, divisor_port], output_unit='Mpkm/cap/a')
+    numerator, numerator_out = _source_node('pkm', 'Mpkm/a')
+    divisor, divisor_out = _source_node('population', 'cap')
+    graph = _build(
+        [numerator, divisor, target],
+        [
+            _edge(numerator, numerator_out, target, numerator_port.id),
+            _tagged_edge(divisor, divisor_out, target, divisor_port.id, ['geometric_inverse']),
+        ],
+    )
+
+    result = graph.solve_constraints()
+    assert result.converged
+    assert _codes(result) == set()
+    assert result.shapes[PortValue(target.uuid, output_id, 'output')].unit == _unit('Mpkm/cap/a')
+
+
+def test_geometric_inverse_factor_is_not_multiplied_into_the_product() -> None:
+    """The pre-fix behaviour — multiplying the divisor — would have to conflict here."""
+    numerator_port = InputPortDef(id=uuid4(), identifier='pkm', unit=_unit('Mpkm/a'))
+    divisor_port = InputPortDef(id=uuid4(), identifier='population', unit=_unit('cap'))
+    target, _output_id = _multiplicative_target([numerator_port, divisor_port], output_unit='Mpkm*cap/a')
+    numerator, numerator_out = _source_node('pkm', 'Mpkm/a')
+    divisor, divisor_out = _source_node('population', 'cap')
+    graph = _build(
+        [numerator, divisor, target],
+        [
+            _edge(numerator, numerator_out, target, numerator_port.id),
+            _tagged_edge(divisor, divisor_out, target, divisor_port.id, ['geometric_inverse']),
+        ],
+    )
+
+    result = graph.solve_constraints()
+    assert 'unit_incompatible' in _codes(result)
+
+
+def test_an_opaque_factor_tag_states_no_product_rule() -> None:
+    """``complement`` re-units its factor, so the product declines rather than guess."""
+    factor_port = InputPortDef(id=uuid4(), identifier='factor', unit=_unit('t/a'))
+    share_port = InputPortDef(id=uuid4(), identifier='share', unit=_unit('%'))
+    target, output_id = _multiplicative_target([factor_port, share_port], output_unit='kg/a')
+    factor, factor_out = _source_node('factor', 't/a')
+    share, share_out = _source_node('share', '%')
+    graph = _build(
+        [factor, share, target],
+        [
+            _edge(factor, factor_out, target, factor_port.id),
+            _tagged_edge(share, share_out, target, share_port.id, ['complement']),
+        ],
+    )
+
+    result = graph.solve_constraints()
+    assert result.converged
+    assert _codes(result) == set()
+    # No product rule was stated, so the output keeps only what it declares.
+    assert result.shapes[PortValue(target.uuid, output_id, 'output')].unit == _unit('kg/a')
+
+
+def _ratio_target(
+    port: InputPortDef,
+    params: list,
+    output_unit: str = '',
+    output_quantity: str | None = None,
+) -> tuple[NodeSnapshot, UUID]:
+    output_id = uuid4()
+    snapshot = NodeSnapshot(
+        uuid=uuid4(),
+        identifier='target',
+        spec=NodeSpec(
+            type_config=SimpleConfig(node_class='simple.AdditiveNode'),
+            input_ports=[port],
+            output_ports=[OutputPortDef(id=output_id, identifier='default', unit=_unit(output_unit), quantity=output_quantity)],
+            params=params,
+        ),
+    )
+    return snapshot, output_id
+
+
+@pytest.mark.parametrize(
+    ('param', 'input_unit', 'input_quantity', 'output_quantity'),
+    [
+        (StringParameter(local_id='reference_category', value='pollutant:co2'), 'g/kWh', 'emission_factor', 'emission_factor'),
+        (StringParameter(local_id='share_dimension', value='age'), 'cap', 'population', 'fraction'),
+    ],
+)
+def test_a_normalizing_additive_node_outputs_a_dimensionless_ratio(
+    param, input_unit: str, input_quantity: str, output_quantity: str
+) -> None:
+    """``reference_category`` and ``share_dimension`` divide the sum by a slice of itself."""
+    port = InputPortDef(id=uuid4(), identifier='additive', multi=True, unit=_unit(input_unit), quantity=input_quantity)
+    target, output_id = _ratio_target(port, [param], output_quantity=output_quantity)
+    source, source_port = _source_node('a', input_unit, quantity=input_quantity)
+    graph = _build([source, target], [_edge(source, source_port, target, port.id)])
+
+    result = graph.solve_constraints()
+    assert result.converged
+    assert _codes(result) == set()
+    output = result.shapes[PortValue(target.uuid, output_id, 'output')]
+    assert output.unit == _unit('')
+    assert output.quantity == output_quantity
+
+
+def test_a_plain_additive_node_still_shares_its_inputs_unit() -> None:
+    """Without a normalizing param the output must keep the inputs' unit."""
+    port = InputPortDef(id=uuid4(), identifier='additive', multi=True, unit=_unit('g/kWh'))
+    target, _output_id = _ratio_target(port, [], output_unit='')
+    source, source_port = _source_node('a', 'g/kWh')
+    graph = _build([source, target], [_edge(source, source_port, target, port.id)])
+
+    result = graph.solve_constraints()
+    assert 'unit_incompatible' in _codes(result)
+
+
+def test_a_normalizing_additive_node_keeps_its_dimensions() -> None:
+    """Dividing by a reference category reindexes nothing, so the dimensions survive."""
+    pollutant = _dimension('pollutant', 'co2', 'nox')
+    port = InputPortDef(id=uuid4(), identifier='additive', multi=True, unit=_unit('g/kWh'))
+    target, output_id = _ratio_target(port, [StringParameter(local_id='reference_category', value='pollutant:co2')])
+    source, source_port = _source_node('a', 'g/kWh', dimensions=['pollutant'])
+    graph = _build([source, target], [_edge(source, source_port, target, port.id)], dimensions=(pollutant,))
+
+    result = graph.solve_constraints()
+    assert result.converged
+    assert _codes(result) == set()
+    assert result.shapes[PortValue(target.uuid, output_id, 'output')].dimensions == {pollutant.id}

--- a/src/nodes/tests/test_instance_parser.py
+++ b/src/nodes/tests/test_instance_parser.py
@@ -305,3 +305,57 @@ include:
 
     with pytest.raises(TypeError, match='nodes_editable must be a boolean'):
         InstanceYAMLConfig.load_for_entrypoint(yaml_path)
+
+
+def _dataset_port_units(node_config: dict[str, Any]) -> dict[str | None, str | None]:
+    snapshot = parse_instance_snapshot(
+        {
+            'id': 'test',
+            'default_language': 'en',
+            'name': 'Test',
+            'owner': 'Owner',
+            'target_year': 2030,
+            'reference_year': 2020,
+            'minimum_historical_year': 2010,
+            'nodes': [node_config],
+        },
+        instance_uuid=uuid4(),
+    )
+    (node,) = snapshot.nodes
+    assert node.spec is not None
+    return {port.identifier: str(port.unit) if port.unit is not None else None for port in node.spec.input_ports}
+
+
+def test_an_authored_dataset_unit_wins_over_the_nodes_own_unit():
+    """
+    On a formula node a dataset is one term, united independently of the result.
+
+    Deriving the port's unit from the node's output metric claims the dataset
+    arrives in `km/cap/d` when it is passenger kilometres, which reads as a
+    constraint conflict against the dataset's own schema.
+    """
+    units = _dataset_port_units({
+        'id': 'active_mobility_distance',
+        'type': 'formula.FormulaNode',
+        'name': 'Active mobility distance',
+        'quantity': 'distance',
+        'unit': 'km/cap/d',
+        'input_datasets': [{'id': 'test/active_mobility', 'unit': 'Mpkm/a'}],
+        'params': [{'id': 'formula', 'value': 'test_active_mobility'}],
+    })
+
+    assert list(units.values()) == ['Mpkm/a']
+
+
+def test_a_dataset_port_without_an_authored_unit_still_takes_the_nodes_unit():
+    """The fallback is unchanged: an unstated unit is the node's own."""
+    units = _dataset_port_units({
+        'id': 'district_heating_consumption',
+        'type': 'simple.AdditiveNode',
+        'name': 'District heating consumption',
+        'quantity': 'energy',
+        'unit': 'GWh/a',
+        'input_datasets': [{'id': 'test/district_heating'}],
+    })
+
+    assert list(units.values()) == ['GWh/a']


### PR DESCRIPTION
## Description
The computed units and tested units differed because geomteric_inverse tag was ignored.

What changed

src/nodes/constraints/tags.py (new, 89 lines) — the tag vocabulary the solver already had, moved out where node classes can reach it too, and extended. shape_rules() is compiled from ports while a tag operation is authored on a binding, so a class that wants to state its algebra has to read the tags back off the bindings. Three cases: neutral (changes nothing a rule says), inverting (geometric_inverse — reciprocal, which ProductShapeRule.inverse_inputs states exactly), opaque (anything else registered — no rule can express it). solver.py now imports from here; its behaviour is unchanged, and geometric_inverse stays opaque at binding level, which is what lets the two mechanisms compose.

MultiplicativeNode / MultiplicativeNode2.shape_rules — factor ports are partitioned into direct and inverse operands instead of all going into inputs. A port mixing inverted with direct deliveries, or carrying any other opaque tag, makes the method state no product rule at all: an unstated constraint is merely incomplete, a wrong one is a false conflict.

AdditiveNode.shape_rules — when reference_category or share_dimension is set, the node divides its sum by a slice of itself, so the output is dimensionless however the inputs are united. That is now stated as two chained rules — inputs share a shape with the sum, then the sum over the sum — which cancels the unit while keeping the dimensions, and leaves the declared quantity alone. AdditiveNode2 needs nothing: it has neither param. MultiplicativeNode declares them but never applies them, so its output really does keep the product's unit — left alone.

instance_parser + spec_export — an authored unit: on an input dataset now outranks the node's own output metric. It compiles to the pipeline's closing ensure_unit, so it is the unit the port receives; falling back to the node's metric only holds for a node whose dataset input is in its own output unit, and on a formula node a dataset is one term.


------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Additional Notes
Any additional information that reviewers should know about this PR.
